### PR TITLE
Small bugfixes around build scripts

### DIFF
--- a/content-scripts/updateDocs.js
+++ b/content-scripts/updateDocs.js
@@ -48,7 +48,7 @@ const getConfig = ({ tmpDir }) => ({
     newBranch: `splitbot/update-docs`,
 
     // Submit a pull request against this branch
-    targetBranch: "next",
+    targetBranch: "master",
 
     // When creating/modifying a version, call these functions according to
     // the name of each subdirectory in the extracted tarball of the asset

--- a/scripts/build_js_static.sh
+++ b/scripts/build_js_static.sh
@@ -3,10 +3,7 @@
 SPLITGRAPH_DIR="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 
 pushd "$SPLITGRAPH_DIR" \
-    && echo "Build @splitgraph/tlib..." \
-    && yarn workspace @splitgraph/tlib build \
-    && echo "Build @splitgraph/tdesign..." \
-    && yarn workspace @splitgraph/tdesign build \
+    && yarn run buildlibs \
     && echo "Build and export @splitgraph/docs..." \
     && yarn workspace @splitgraph/docs build \
     && popd \

--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,7 @@
 # Simply run:
 # ./setup.sh
 
-SPLITGRAPH_DIR="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
+SPLITGRAPH_DIR=${1-"$(cd -P -- "$(dirname -- "$0")" && pwd -P)"}
 
 prep_env() {
     echo "Ensure certs..." \


### PR DESCRIPTION
Tiny bugfixes, mostly unrelated to this repository

- Point updateDocs script to master
- Allow `setup.sh` to take an argument for working dir, so other JS monorepos can use it without duplicating code