### PR TITLE
Obsessively and aggressively optimize styling of website

### DIFF
--- a/design/Layout/Containers/MainContent.js
+++ b/design/Layout/Containers/MainContent.js
@@ -2,16 +2,12 @@ import { Box } from "../../index";
 
 const Style = {
   backgroundColor: "#fff",
-  "@media (min-width: 769px)": {
-    overflowY: "auto",
-    MsOverflowStyle: "-ms-autohiding-scrollbar",
-    paddingBottom: "8rem",
-    maxWidth: "100ch",
-  },
   // 3rem for header size
   minHeight: "calc(100vh - 3rem)",
 };
 
-export default ({ children, gridArea = "content" }) => (
-  <Box sx={{ gridArea, ...Style }}>{children}</Box>
+export default ({ children }) => (
+  <Box className="main-content" sx={{ ...Style }}>
+    {children}
+  </Box>
 );

--- a/design/Layout/Footer/Footer.js
+++ b/design/Layout/Footer/Footer.js
@@ -1,7 +1,3 @@
 import { Box } from "../../index";
 
-export default ({ children, gridArea = "footer" }) => (
-  <Box backgroundColor="heavy" sx={{ gridArea, color: "background" }}>
-    {children}
-  </Box>
-);
+export default ({ children }) => <Box className="footer">{children}</Box>;

--- a/design/Layout/HolyGrail/HolyGrail.js
+++ b/design/Layout/HolyGrail/HolyGrail.js
@@ -5,7 +5,7 @@ export const GridArea = {
   Nav: "nav",
   Content: "content",
   Side: "side",
-  Footer: "footer"
+  Footer: "footer",
 };
 
 export default ({ children }) => (
@@ -15,13 +15,49 @@ export default ({ children }) => (
       gridGap: 4,
       gridTemplateAreas: `
           "${GridArea.Header} ${GridArea.Header}  ${GridArea.Header}"
-          "${GridArea.Nav}    ${GridArea.Content} ${GridArea.Side}"
+          "${GridArea.Nav}    ${GridArea.Content} ${GridArea.Content}"
           "${GridArea.Footer} ${GridArea.Footer}  ${GridArea.Footer}"
       `,
-      gridTemplateColumns: "300px 1fr 300px",
+      gridTemplateColumns: "300px 1fr",
       gridTemplateRows: "auto 100vh 1fr auto auto",
       gridGap: 0,
       maxHeight: "100vh",
+      ".right-sidebar": {
+        "@media (min-width: 769px)": {
+          position: "absolute",
+          top: "75px",
+          left: "calc((100vw - 600px - 100ch)/2 + 300px + 100ch + 2rem)",
+          maxWidth: "300px",
+          maxHeight: "calc(100vh - 100px)",
+          overflowY: "auto",
+        },
+        "@media (max-width: 1570px)": {
+          display: "none",
+        },
+      },
+      ".content-wrapper": {
+        backgroundColor: "#fff",
+        minHeight: "calc(100vh - 3rem)",
+        overflowY: "auto",
+        gridArea: GridArea.Content,
+      },
+      ".main-content": {
+        "@media (min-width: 769px)": {
+          MsOverflowStyle: "-ms-autohiding-scrollbar",
+          paddingLeft: "calc((100vw - 600px - 100ch)/2)",
+          paddingRight: "calc((100vw - 600px - 100ch)/2 + 300px)",
+          scrollbarWidth: "thin",
+        },
+      },
+      ".footer": {
+        borderTop: "1px solid #efefef",
+        paddingBottom: "8rem",
+        // backgroundColor: "#efefef",
+        width: "100%",
+        a: {
+          variant: "links.primary",
+        },
+      },
       "@media (max-width: 768px)": {
         gridTemplateAreas: `
           "${GridArea.Header}"
@@ -37,8 +73,8 @@ export default ({ children }) => (
           auto
           minmax(75px, auto)
           auto
-        `
-      }
+        `,
+      },
     }}
   >
     {children}

--- a/design/Layout/Sidebar/Sidebar.js
+++ b/design/Layout/Sidebar/Sidebar.js
@@ -41,12 +41,12 @@ const getInlineFooterStyle = ({ depth, show, initialDepth, loading }) => ({
       align: "flex",
       alignItems: "flex-end",
       justifyContent: "center",
-      display: "flex"
-    }
+      display: "flex",
+    },
   },
   "@media (min-width: 769px)": {
-    display: "none"
-  }
+    display: "none",
+  },
 });
 
 const DopeWaterLoadingAnimation = ({ loading }) => {
@@ -73,28 +73,28 @@ const DopeWaterLoadingAnimation = ({ loading }) => {
       WebkitAnimation: "animtop 5s forwards, animtop2 2s forwards",
       animation: "animtop 5s forwards, animtop2 2s forwards",
       borderBottomLeftRadius: "40px",
-      borderBottomRightRadius: "40px"
+      borderBottomRightRadius: "40px",
     },
     "@-webkit-keyframes animtop": {
       "0%": {
-        top: "100%"
+        top: "100%",
       },
       "75%": {
-        top: 0
-      }
+        top: 0,
+      },
     },
     "@keyframes animtop": {
       "0%": { top: "100%" },
-      "100%": { top: "25%" }
+      "100%": { top: "25%" },
     },
     "@-webkit-keyframes animtop2": {
       "75%": { top: "25%" },
-      "100%": { top: 0 }
+      "100%": { top: 0 },
     },
     "@keyframes animtop2": {
       "75%": { top: "25%" },
-      "100%": { top: 0 }
-    }
+      "100%": { top: 0 },
+    },
   };
 
   const containerStyle = useMemo(
@@ -116,9 +116,9 @@ const ResetButton = ({ reset, show }) => {
         textTransform: "uppercase",
         fontSize: "1rem",
         ":hover": {
-          cursor: "pointer"
+          cursor: "pointer",
         },
-        display: show ? "initial" : "none"
+        display: show ? "initial" : "none",
       }}
       onClick={reset}
     >
@@ -132,7 +132,7 @@ const SidebarInlineFooter = ({
   lastClickedDepth,
   initialDepth,
   loading,
-  reset
+  reset,
 }) => {
   const visibleDepth = nextDepth || lastClickedDepth || initialDepth;
   const show = loading || visibleDepth > initialDepth;
@@ -141,7 +141,7 @@ const SidebarInlineFooter = ({
     depth: visibleDepth,
     show,
     initialDepth,
-    loading
+    loading,
   });
 
   return (
@@ -167,7 +167,7 @@ const SidebarNode = ({
   activeNodePath,
   onClickNode,
   acquireMutex,
-  mutex
+  mutex,
 }) => {
   const {
     depth,
@@ -175,7 +175,7 @@ const SidebarNode = ({
     parentNodeId,
     slug,
     metadata: { title } = {},
-    children
+    children,
   } = node;
 
   const isParent = !!children && children.length > 0;
@@ -192,7 +192,7 @@ const SidebarNode = ({
     isInLastClickedPath,
     anythingBeenClicked,
     isChildOfClickedParent,
-    isChildOfActiveParent
+    isChildOfActiveParent,
   } = useSidebarNode({
     nodeId,
     onClickNode,
@@ -206,7 +206,7 @@ const SidebarNode = ({
     minLabelDepth,
     depth,
     isParent,
-    isNavigable
+    isNavigable,
   });
 
   const item = (
@@ -227,7 +227,7 @@ const SidebarNode = ({
       {children && (
         <div className="ul-wrapper" sx={childListContainerStyle}>
           <ul key={`${slug}`} sx={childListStyle}>
-            {children.map(child => (
+            {children.map((child) => (
               <SidebarNode
                 key={`${child.slug}`}
                 Link={Link}
@@ -268,7 +268,7 @@ const Sidebar = ({
   lastClickedDepth,
   nextDepth,
   initialDepth,
-  reset
+  reset,
 }) => {
   return (
     <>
@@ -314,7 +314,7 @@ const SidebarRoot = ({
   matchActiveNode,
   activeNodeId,
   idKey,
-  initialDepth
+  initialDepth,
 }) => {
   const {
     loading,
@@ -326,24 +326,25 @@ const SidebarRoot = ({
     onClickNode,
     acquireMutex,
     mutex,
-    reset
+    reset,
   } = useSidebar({
     contentTree: rootNode,
     activeNodeId,
     matchActiveNode,
     idKey,
-    initialDepth
+    initialDepth,
   });
 
   return (
     <Box
+      className="sgr-sidebar--root"
       sx={{
         gridArea,
         ...SidebarStyle.Container,
         ul: SidebarStyle.List,
         ".ul-wrapper": SidebarStyle.ListContainer,
         ".li-selector": SidebarStyle.Item,
-        "span,a": SidebarStyle.Label
+        "span,a": SidebarStyle.Label,
       }}
       fontSize={2}
     >

--- a/design/Layout/Sidebar/SidebarLabel.js
+++ b/design/Layout/Sidebar/SidebarLabel.js
@@ -45,7 +45,7 @@ const ClassNames = {
   // This is dynamic, and we use it for padding, but realistically there is a
   // max, so we can still use the selector system to assign
   Depth: (depth, minLabelDepth = 0) =>
-    `sgr-sidebar-depth-${depth - minLabelDepth}`
+    `sgr-sidebar-depth-${depth - minLabelDepth}`,
 };
 
 const Selectors = Object.keys(ClassNames).reduce(
@@ -55,7 +55,7 @@ const Selectors = Object.keys(ClassNames).reduce(
       typeof ClassNames[classNameKey] === "string"
         ? ClassNames[classNameKey]
         : "doesnotexist"
-    }`
+    }`,
   }),
   {}
 );
@@ -65,7 +65,7 @@ const getHardcodedDepthStyles = (maxHardCodedDepth = 10) => {
   const depthStyles = {
     Base: {},
     Vertical: {},
-    Horizontal: {}
+    Horizontal: {},
   };
 
   // Don't count the root nodes, we want to set their style separately
@@ -80,7 +80,7 @@ const getHardcodedDepthStyles = (maxHardCodedDepth = 10) => {
 
       paddingLeft:
         depth >= 1 ? `${marginLeft + paddingLeft}rem !important` : "initial",
-      marginRight: depth >= 1 ? `${marginLeft}rem` : "initial"
+      marginRight: depth >= 1 ? `${marginLeft}rem` : "initial",
     };
 
     depthStyles.Vertical[
@@ -90,7 +90,7 @@ const getHardcodedDepthStyles = (maxHardCodedDepth = 10) => {
     ] = {
       borderBottomStyle: "solid",
       borderBottomWidth: "2px",
-      borderBottomColor: "lightgray"
+      borderBottomColor: "lightgray",
     };
 
     depthStyles.Vertical[
@@ -102,7 +102,7 @@ const getHardcodedDepthStyles = (maxHardCodedDepth = 10) => {
       borderBottomWidth: "2px",
       borderBottomColor: "lightgray",
       borderLeftColor: "primary",
-      borderRightStyle: "solid"
+      borderRightStyle: "solid",
     };
   }
 
@@ -112,12 +112,12 @@ const getHardcodedDepthStyles = (maxHardCodedDepth = 10) => {
 const hideSidebars = {
   "ul::-webkit-scrollbar": {
     width: 0,
-    height: 0
+    height: 0,
   },
   "ul::-webkit-scrollbar-button": {
     width: 0,
-    height: 0
-  }
+    height: 0,
+  },
 };
 
 const styles = {
@@ -126,18 +126,18 @@ const styles = {
     ...hideSidebars,
     BaseLabel: {},
     RootLabel: {},
-    ChildLabel: {}
+    ChildLabel: {},
   },
   Horizontal: {
     [`${Selectors.ActiveParentNodeAndNothingClicked}:after,
       ${Selectors.ClickedParentNode}:after`]: {
       content: '"\\25BC"',
       fontSize: ".7em",
-      paddingLeft: 2
+      paddingLeft: 2,
     },
 
     [`a${Selectors.ChildNode}`]: {
-      boxShadow: "0 0 4px rgba(0, 0, 0, .125)"
+      boxShadow: "0 0 4px rgba(0, 0, 0, .125)",
     },
 
     [`${Selectors.Base}`]: {
@@ -152,28 +152,28 @@ const styles = {
       borderBottom: "1px",
       borderBottomColor: "primary",
       color: "primary",
-      scrollSnapAlign: "center"
+      scrollSnapAlign: "center",
     },
 
     [`${Selectors.LastClicked}`]: {
-      textDecoration: "underline"
+      textDecoration: "underline",
     },
 
     [`${Selectors.ActiveNode}, ${Selectors.InActivePath}`]: {
       // color: "purple",
       borderLeftWidth: "2px",
       borderLeftStyle: "solid",
-      borderLeftColor: "primary"
+      borderLeftColor: "primary",
     },
 
     [`${Selectors.MutedNode}`]: {
       opacity: 0.5,
-      backgroundColor: "gray"
+      backgroundColor: "gray",
     },
 
     [`${Selectors.ActiveNode},${Selectors.InActivePath}`]: {
-      fontWeight: "bold"
-    }
+      fontWeight: "bold",
+    },
   },
   Vertical: {
     [`${Selectors.Base}`]: {
@@ -182,10 +182,10 @@ const styles = {
       alignItems: "center",
       height: "2rem",
       cursor: "pointer",
-      borderRightWidth: "1px",
+      borderRightWidth: "0px",
       borderRightColor: "lightgray",
       borderRightStyle: "solid",
-      backgroundColor: "#efefef"
+      backgroundColor: "#efefef",
     },
 
     [`${Selectors.MutedNode}`]: {
@@ -210,26 +210,28 @@ const styles = {
 
     // 1. Child node, may also be parent node. Definitely not root node.
     [`${Selectors.ChildNode}`]: {
-      paddingTop: 1,
-      paddingBottom: 1,
+      // paddingTop: 1,
+      // paddingBottom: 1,
+      paddingTop: 0,
+      paddingBottom: 0,
       borderLeftWidth: "4px",
       borderLeftStyle: "solid",
       ":hover": {
         borderColor: "white",
         // backgroundColor: "white"
-        textDecoration: "underline"
-      }
+        textDecoration: "underline",
+      },
     },
 
     [`${Selectors.ChildOfActiveParent}`]: {
       borderLeftWidth: "4px",
       ":hover": {
-        borderLeftColor: "primary"
-      }
+        borderLeftColor: "primary",
+      },
     },
 
     [`${Selectors.ActiveParentNode} ul`]: {
-      backgroundColor: "primary !important"
+      backgroundColor: "primary !important",
     },
 
     // 2. Parent Node, may also be child node or root node.
@@ -242,7 +244,7 @@ const styles = {
       fontWeight: "bold",
       fontVariant: "small-caps",
       fontSize: "0.8em",
-      textTransform: "uppercase"
+      textTransform: "uppercase",
     },
 
     [`${Selectors.InActivePath}`]: {
@@ -252,38 +254,38 @@ const styles = {
       ":hover": {
         borderLeftColor: "primary",
         borderLeftStyle: "solid",
-        borderLeftWidth: "4px"
-      }
+        borderLeftWidth: "4px",
+      },
     },
 
     // 3. Root node, may also be parent node. Definitely not child node.
     [`${Selectors.RootNode}`]: {
-      paddingTop: "1rem",
+      // paddingTop: "1rem",
+      paddingTop: 0,
       paddingLeft: "8px",
       justifyContent: "flex-end",
       paddingRight: "8px",
       borderLeftStyle: "none",
       backgroundColor: "#efefef",
-      paddingTop: "8px",
       borderTopStyle: "none",
       borderTopColor: "primary",
       borderTopWidth: "4px",
       ":hover": {
         borderLeftWidth: "0px",
-        borderLeftStyle: "none"
-      }
+        borderLeftStyle: "none",
+      },
     },
 
     [`${Selectors.RootNode}${Selectors.InActivePath}`]: {
-      backgroundColor: "#fff"
+      backgroundColor: "#fff",
     },
 
     [`${Selectors.ParentNode}${Selectors.InActivePath}, ${Selectors.ParentNode}${Selectors.InLastClickedPath}`]: {
-      backgroundColor: "#fff"
+      backgroundColor: "#fff",
     },
 
     [`${Selectors.ParentNode}${Selectors.LastClicked}`]: {
-      backgroundColor: "#fff"
+      backgroundColor: "#fff",
     },
 
     [`${Selectors.ActiveNode}`]: {
@@ -309,10 +311,10 @@ const styles = {
         borderTopColor: "lightgray",
         borderBottomColor: "lightgray",
         borderTopWidth: "1px",
-        borderBottomWidth: "1px"
-      }
-    }
-  }
+        borderBottomWidth: "1px",
+      },
+    },
+  },
 };
 
 const Style = {
@@ -320,12 +322,12 @@ const Style = {
   ...getHardcodedDepthStyles().Base,
   "@media (min-width: 769px)": {
     ...styles.Vertical,
-    ...getHardcodedDepthStyles().Vertical
+    ...getHardcodedDepthStyles().Vertical,
   },
   "@media (max-width: 768px)": {
     ...styles.Horizontal,
-    ...getHardcodedDepthStyles().Horizontal
-  }
+    ...getHardcodedDepthStyles().Horizontal,
+  },
 };
 
 const getClassNames = ({
@@ -340,7 +342,7 @@ const getClassNames = ({
   isChildOfActiveParent,
   isChildOfClickedParent,
   depth,
-  minLabelDepth
+  minLabelDepth,
 }) => {
   const classNames = [ClassNames.Base];
 
@@ -408,14 +410,14 @@ const getClassNames = ({
   return classNames.join(" ");
 };
 
-const hideScrollbars = el => {
+const hideScrollbars = (el) => {
   el.style["::-webkit-scrollbar"] =
     "width: 0 !important; background: transparent;";
   el.style["overflow"] = "-moz-scrollbars-none";
   el.style["-ms-overflow-style"] = "none";
 };
 
-const revealScrollbars = el => {
+const revealScrollbars = (el) => {
   el.style["-webkit-scrollbar"] = "initial";
   // el.style["overflow"] = "initial";
   el.style["-ms-overflow-style"] = "initial";
@@ -426,7 +428,7 @@ const useScrollToActiveNode = ({
   isInActivePath,
   isInLastClickedPath,
   containerEl,
-  anythingBeenClicked
+  anythingBeenClicked,
 }) => {
   useLayoutEffect(() => {
     const scrollTarget = containerEl.current;
@@ -462,7 +464,7 @@ const SidebarLabel = ({
   isLastClicked,
   isInActivePath,
   isInLastClickedPath,
-  anythingBeenClicked
+  anythingBeenClicked,
 }) => {
   const {
     depth,
@@ -471,7 +473,7 @@ const SidebarLabel = ({
     slug,
     metadata: { title, sidebarTitle = null } = {},
     children,
-    parentNodeId
+    parentNodeId,
   } = node;
   const isParent = children && children.length > 0;
   const isChild = !!parentNodeId;
@@ -488,7 +490,7 @@ const SidebarLabel = ({
     isChildOfActiveParent,
     isChildOfClickedParent,
     depth,
-    minLabelDepth
+    minLabelDepth,
   });
 
   const labelContainerId = `sgr-sidebar-label-container-${nodeId}`;
@@ -500,7 +502,7 @@ const SidebarLabel = ({
     isInActivePath,
     isInLastClickedPath,
     containerEl,
-    anythingBeenClicked
+    anythingBeenClicked,
   });
 
   const _title = sidebarTitle || title;

--- a/design/Layout/Sidebar/SidebarStyle.js
+++ b/design/Layout/Sidebar/SidebarStyle.js
@@ -94,7 +94,7 @@ const VerticalStyle = {
     MsOverflowStyle: "-ms-autohiding-scrollbar",
     scrollbarWidth: "thin",
     paddingBottom: "8rem",
-    scrollSnapType: "y mandatory",
+    // scrollSnapType: "y mandatory",
     // scrollPaddingRight: "200px",
     scrollPaddingBottom: "200px",
 

--- a/design/css/base.css
+++ b/design/css/base.css
@@ -1,12 +1,18 @@
+* {
+  scrollbar-width: thin;
+}
+
 html,
 body {
   padding: 0;
   margin: 0;
   border: 0;
 
-  font-family: "Open Sans", sans-serif;
+  /* font-family: "Open Sans", sans-serif; */
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
+    sans-serif, Apple Color Emoji, Segoe UI Emoji;
+
   overflow-y: auto;
-  /* overflow:auto; */
 }
 
 @media (max-width: 768px) {
@@ -15,35 +21,55 @@ body {
   }
 }
 
-/*
-ul::-webkit-scrollbar {
-  width: 0;
-  height: 0;
+*::-webkit-scrollbar-thumb {
+  background: #888;
+  border-radius: 10px;
 }
-ul::-webkit-scrollbar-button {
-  width: 0;
-  height: 0;
+
+*::-webkit-scrollbar-track {
+  background: #efefef;
+  border-radius: 10px;
 }
-ul::-webkit-scrollbar-thumb {
-  background: #36678d;
-  border: none;
-  border-radius: 0;
+
+.main-content::-webkit-scrollbar-track {
+  background: #fff;
 }
-ul::-webkit-scrollbar-thumb:hover {
-  background: #ffffff;
+
+*::-webkit-scrollbar {
+  width: 7px;
+  height: 7px;
 }
-ul::-webkit-scrollbar-thumb:active {
-  background: #000000;
+
+/* sidebar scrollbar should be color of content area */
+.sgr-sidebar--root::-webkit-scrollbar-track {
+  background: #fff;
 }
-ul::-webkit-scrollbar-track {
-  background: #dddddf;
+
+/* pre scrollbar should be color of pre */
+pre::-webkit-scrollbar-track {
+  background: #36668d;
 }
-ul::-webkit-scrollbar-track:hover {
-  background: #dddddf;
+
+/* Make sure no scrollbars show up in responsive mode sidebar
+   (phones don't have scrollbars, but shrinking desktop
+   browser window shouldn't have scrollbars either) */
+@media (max-width: 768px) {
+  .sgr-sidebar--root ul::-webkit-scrollbar {
+    width: 0px !important;
+    height: 0px !important;
+  }
+
+  .sgr-sidebar--root ul::-webkit-scrollbar-thumb {
+    background: initial;
+    border-radius: initial;
+  }
+
+  .sgr-sidebar--root ul::-webkit-scrollbar-track {
+    background: initial;
+    border-radius: initial;
+  }
+
+  .sgr-sidebar--root ul {
+    scrollbar-width: none !important;
+  }
 }
-ul::-webkit-scrollbar-track:active {
-  background: #dddddf;
-}
-ul::-webkit-scrollbar-corner {
-  background: transparent;
-} */

--- a/design/themes/defaultTheme.js
+++ b/design/themes/defaultTheme.js
@@ -116,7 +116,8 @@ export const defaultTheme = {
     },
   },
   fonts: {
-    body: "system-ui, sans-serif",
+    body:
+      "-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji",
     heading: "inherit",
     monospace: "Menlo, monospace",
   },
@@ -127,6 +128,8 @@ export const defaultTheme = {
     bold: 700,
   },
   lineHeights: {
+    // body: 1.5,
+    // heading: 1.25,
     body: 1.5,
     heading: 1.25,
   },
@@ -294,6 +297,8 @@ export const defaultTheme = {
     },
     inlineCode: {
       ...prismTheme,
+      color: prismTheme.backgroundColor,
+      backgroundColor: prismTheme.color,
       "@media (min-width: 749px)": {
         minWidth: "initial",
       },
@@ -305,7 +310,7 @@ export const defaultTheme = {
       display: "inline-flex",
       alignContent: "center",
       overflowX: "auto",
-      backgroundColor: "primary",
+      // backgroundColor: "primary",
     },
     code: {
       backgroundColor: "primary",

--- a/docs/pages/index.js
+++ b/docs/pages/index.js
@@ -430,9 +430,9 @@ const LandingPage = () => {
       <section
         className="lp-section lp-cta"
         sx={{
-          minWidth: "100vw",
-          maxWidth: "100vw",
-          width: "100vw",
+          minWidth: "100%",
+          maxWidth: "100%",
+          width: "100%",
           backgroundColor: "heavy",
           paddingTop: "3rem",
           paddingBottom: "3rem",
@@ -476,8 +476,8 @@ const LandingPage = () => {
             position: "position: absolute",
             left: 0,
             top: 0,
-            minWidth: "100vw",
-            width: "100vw",
+            minWidth: "100%",
+            width: "100%",
             height: "400px",
             border: "none",
             background: "none",

--- a/docs/public/static/asciinema/player/asciinema-player-v2.6.1.css
+++ b/docs/public/static/asciinema/player/asciinema-player-v2.6.1.css
@@ -9,13 +9,25 @@ html,
 body {
   margin: 0;
   padding: 0;
-  scrollbar-width: none;
+  scrollbar-width: none !important;
+  -ms-overflow-style: none;
+}
+
+* > * {
+  -ms-overflow-style: none;
+  scrollbar-width: none !important;
+  -ms-overflow-style: none !important;
+}
+
+* > *::--webkit-scrollbar {
+  width: 0px !important;
 }
 
 .asciinema-player-wrapper {
   position: relative;
   text-align: center;
   outline: none;
+  background-color: white;
 }
 .asciinema-player-wrapper .title-bar {
   display: none;
@@ -156,6 +168,10 @@ body {
   }
 }
 
+.asciinema-terminal::-webkit-scrollbar {
+  width: 0px;
+}
+
 .asciinema-terminal {
   box-sizing: content-box;
   -moz-box-sizing: content-box;
@@ -180,7 +196,7 @@ body {
   /* 47px = height of control bar (32px + 15px padding) */
   /* use vh instead of % or it won't work in FF */
   height: calc(100vh - 47px) !important;
-  overflow-y: scroll;
+  overflow-y: auto;
   scroll-snap-type: y mandatory;
   scroll-padding-top: calc(100vh - 100px);
   scrollbar-width: none;

--- a/templaters/layouts/contentWrappers.js
+++ b/templaters/layouts/contentWrappers.js
@@ -6,12 +6,13 @@ const TocStyle = {
   ...tocStyles,
   "ol.toc-level": {
     ...tocStyles["ol.toc-level"],
-    fontSize: 1,
-    padding: "0.5em !important",
-    whiteSpace: "nowrap",
-    overflowX: "hidden",
-    listStyleType: "none"
-  }
+    // fontSize: 1,
+    padding: "0.75em !important",
+    listStyleType: "none",
+    li: {
+      marginBottom: "0.5em",
+    },
+  },
 };
 
 const findMatchingElement = (children = [], matchFunc) => {
@@ -45,7 +46,7 @@ const findMatchingElement = (children = [], matchFunc) => {
 export const OnlyTOC = ({ children, ...rest }) => {
   const originalToc = findMatchingElement(
     React.Children.toArray(children),
-    el =>
+    (el) =>
       el.props &&
       (el.props.name === "nav" ||
         (el.type === "nav" && el.props.className === "toc"))

--- a/templaters/layouts/withDocsLayout.js
+++ b/templaters/layouts/withDocsLayout.js
@@ -27,6 +27,7 @@ import { OnlyTOC } from "./contentWrappers";
 import { defaultTheme } from "@splitgraph/design";
 
 import { NextSeo } from "next-seo";
+import { Helmet } from "react-helmet";
 
 const mdxComponents = {
   pre: ({ children, ...rest }) => (
@@ -152,6 +153,34 @@ const withDocsLayout = ({
       <BaseLayout>
         <DocsPageSeo currentURL={currentURL} />
 
+        <Helmet
+          style={[
+            {
+              cssText: `
+            body {
+                overflow-x: hidden;
+
+                /* so header doesn't disappear when clicking anchor tags */
+                scroll-padding-top: 75px;
+            }
+
+            @media (min-width: 769px) {
+              body {
+                overflow-y: hidden !important;
+              }
+            }
+
+            /* 1570px is when the right sidebar appears */
+            @media (min-width: 1571px) {
+              .main-content nav.toc {
+                display: none;
+              }
+            }
+        `,
+            },
+          ]}
+        />
+
         <HolyGrail.Layout>
           <Header gridArea={HolyGrail.GridArea.Header}>
             <LogoImage logoURL="/static/splitgraph_logo.svg" />
@@ -168,25 +197,40 @@ const withDocsLayout = ({
             initialDepth={activeNodeDepth}
           />
 
-          <MainContent gridArea={HolyGrail.GridArea.Content}>
-            <ContentHeader depth={activeNode.depth}>
-              <Heading>{meta.title}</Heading>
-            </ContentHeader>
-            <ContentBody>
-              <MdxPage components={mdxComponents} />
-            </ContentBody>
-            <ContentFooter>
-              <InterPageNav
-                Link={Link}
-                up={activeNode.up}
-                left={activeNode.left}
-                right={activeNode.right}
-              />
-            </ContentFooter>
-          </MainContent>
+          <Box className="content-wrapper">
+            <MainContent>
+              <ContentHeader depth={activeNode.depth}>
+                <Heading>{meta.title}</Heading>
+              </ContentHeader>
+              <ContentBody>
+                <MdxPage components={mdxComponents} />
+              </ContentBody>
+              <ContentFooter>
+                <InterPageNav
+                  Link={Link}
+                  up={activeNode.up}
+                  left={activeNode.left}
+                  right={activeNode.right}
+                />
+              </ContentFooter>
+            </MainContent>
+            <Footer gridArea={HolyGrail.GridArea.Footer}>
+              <ul>
+                <li>
+                  <Link href="/">Index</Link>
+                </li>
+                <li>
+                  <Link href="/">Somewhere</Link>
+                </li>
+                <li>
+                  <Link href="/">Else</Link>
+                </li>
+              </ul>
+            </Footer>
+          </Box>
 
           <Box
-            gridArea={HolyGrail.GridArea.Side}
+            className="right-sidebar"
             sx={{
               a: defaultTheme.links.primary,
               display: ["none", "none", "initial"],
@@ -194,20 +238,6 @@ const withDocsLayout = ({
           >
             <TocMdx />
           </Box>
-
-          <Footer gridArea={HolyGrail.GridArea.Footer}>
-            <ul>
-              <li>
-                <Link href="/">Index</Link>
-              </li>
-              <li>
-                <Link href="/">Somewhere</Link>
-              </li>
-              <li>
-                <Link href="/">Else</Link>
-              </li>
-            </ul>
-          </Footer>
         </HolyGrail.Layout>
       </BaseLayout>
     );


### PR DESCRIPTION
- Remove extraneous scrollbars
- When scrollbars necessary, style them to look good
- Change `HolyGrail` layout to use absolute positioning of right sidebar,
  so that content scrolls with page (actually, it's an inner container scrolling,
  but it goes all the way to the side -- the body does not scroll)
- Set the footer to 100% of the content area instead of the page
- Decrease padding in left sidebar (increase density)
- Increase font size in right scrollbar, add spacing, word wrap, and
  scroll if necessary when overflow Y
- Add scroll margin to body so that when clicking anchors, the header
  does not disappear
- Remove scroll snapping from left sidebar when not in mobile view
- Change fonts from open sans to system font (same as github)
- Fix some overflow issues on the index LP (scrolling in iframe not yet addressed)
- Add padding to sides of content so it's positioned in the middle of page
- Position the right sidebar next to the content in middle of page
- Hide TOC in content when TOC in right sidebar exists (breakpoint 1570px)