### PR TITLE
More marketing copy, couple of design fixes

### DIFF
--- a/content/about/0000_company/0000_team.mdx
+++ b/content/about/0000_company/0000_team.mdx
@@ -12,7 +12,7 @@ export const meta = {
 `phb` is a chat bot that has two purposes:
 
   * Sending "standup request messages" at 9AM every morning, giving each team member a configurable
-    amount of time to respond. PHB also keeps track of the stream of standup messages that were
+    amount of time to respond. PHB also keeps track of the streak of standup messages that were
     sent on time. If the streak is broken, there are precisely no consequences.
   * Picking a question from the [1-on-1 meeting question bank](https://github.com/VGraupera/1on1-questions) and sending it to the team chat, targeting a specific team member. This happens at random intervals defined by the [exponential distribution](https://en.wikipedia.org/wiki/Exponential_distribution), often at night, and offers a true clueless middle management experience.
 

--- a/content/about/0000_company/0000_team.mdx
+++ b/content/about/0000_company/0000_team.mdx
@@ -3,4 +3,17 @@ export const meta = {
   title: "Splitgraph Team",
 };
 
-# Splitgraph Team
+## Artjoms Iškovs
+
+## Miles Richardson
+
+## `phb`
+
+`phb` is a chat bot that has two purposes:
+
+  * Sending "standup request messages" at 9AM every morning, giving each team member a configurable
+    amount of time to respond. PHB also keeps track of the stream of standup messages that were
+    sent on time. If the streak is broken, there are precisely no consequences.
+  * Picking a question from the [1-on-1 meeting question bank](https://github.com/VGraupera/1on1-questions) and sending it to the team chat, targeting a specific team member. This happens at random intervals defined by the [exponential distribution](https://en.wikipedia.org/wiki/Exponential_distribution), often at night, and offers a true clueless middle management experience.
+
+`phb` refused to provide biographical details when asked.

--- a/content/about/0000_company/0010_contact.mdx
+++ b/content/about/0000_company/0010_contact.mdx
@@ -3,4 +3,8 @@ export const meta = {
   title: "Contact",
 };
 
-# Contact Splitgraph
+Splitgraph Limited is a company registered in England and Wales (no. 11657324) at 6 Prince Andrew Court, 166 High Street, Chesterton, Cambridge, CB4 1NS, United Kingdom.
+
+**Press enquiries**: [press@splitgraph.com](mailto:press@splitgraph.com)
+
+**All other enquiries**: [support@splitgraph.com](mailto:support@spligraph.com)

--- a/content/docs/0000_getting-started/0150_frequently-asked-questions.mdx
+++ b/content/docs/0000_getting-started/0150_frequently-asked-questions.mdx
@@ -21,6 +21,12 @@ to build the engine or contact us.
 You can also add the Splitgraph engine as a PostgreSQL [logical replication client](../ingesting-data/postgres-replication),
 which will let you ingest data from existing databases without installing Splitgraph on them.
 
+### Does my data have to be in PostgreSQL to use Splitgraph?
+
+With [foreign data wrappers](../ingesting-data/foreign-data-wrappers/introduction), you can query
+data in other databases (including MongoDB, MySQL or PostgreSQL) directly through Spligraph with
+[any PostgreSQL client](../integrating-splitgraph/other-clients). You do not need to copy your data into PostgreSQL to use Splitgraph.
+
 ### Why PostgreSQL? Why not write your own database?
 
 PostgreSQL is a battle-tested RDBMS with a mature feature set (ACID transactions, authentication,
@@ -52,7 +58,7 @@ We were guided by the same principles when building Splitgraph.
 We maintain a couple of Jupyter notebooks with benchmarks on [our GitHub](https://github.com/splitgraph/splitgraph/tree/master/examples/benchmarking).
 
 It's difficult to specify what is considered a benchmark for Splitgraph, as for a lot of operations
-one would be benchmarking PostgreSQL itself. This is why we haven't run benchmarks like [TPC-DS](https://www.tpc.org/tpcds/) on Splitgraph
+one would be benchmarking PostgreSQL itself. This is why we haven't run benchmarks like [TPC-DS](http://www.tpc.org/tpcds/) on Splitgraph
 (since for maximum performance, it's easy to check out a Splitgraph image into a PostgreSQL schema)
 but have tested the overhead of various Splitgraph workloads over PostgreSQL.
 
@@ -106,7 +112,7 @@ transformations from reusable and versionable SQL snippets.
 dbt is enhanced by Splitgraph: since a Splitgraph engine is also a PostgreSQL instance, dbt can
 work against it, getting benefits like version control, packaging and sharing to datasets that it uses and builds.
 
-We have an example of running [dbt](../integrating-splitgraph/dbt) in such way, swapping between different versions of the
+We have an example of running [dbt](../integrating-splitgraph/dbt) in such a way, swapping between different versions of the
 source dataset and looking at their effect on the built dbt model.
 
 Splitgraph also offers its own method of building datasets: [Splitfiles](../concepts/splitfiles). Splitfiles offer Dockerfile-like caching, provenance tracking, fast dataset rebuilds, joins between datasets and full SQL support.
@@ -116,9 +122,9 @@ transformations are treated as pure functions between isolated self-contained da
 
 #### Databricks
 
-Databricks offers a full take-it-or-leave-it platform for data governance, whereas Splitgraph allows you to pick and choose parts of your workflow that you wish to swap out with Splitgraph.
+Databricks offers a full take-it-or-leave-it platform for doing data science, including a managed Spark cluster, whereas Splitgraph allows you to pick and choose parts of your workflow that you wish to swap out with Splitgraph.
 
-Splitgraph encourages users to transform data using reproducible [Splitfiles](../concepts/splitfiles) that allow hermetic dataset builds rather than ad hoc notebooks.
+Rather than ad hoc notebooks, Splitgraph encourages users to transform data using reproducible [Splitfiles](../concepts/splitfiles) that allow hermetic dataset builds.
 
 Same Splitgraph workflows can be applied in development as in production, with the user's local engine. This brings iteration times down and lets you maintain a single codebase for your data transformations.
 

--- a/content/docs/0300_ingesting-data/0200_postgres-replication.mdx
+++ b/content/docs/0300_ingesting-data/0200_postgres-replication.mdx
@@ -3,7 +3,7 @@ export const meta = {
   title: "PostgreSQL replication client",
 };
 
-It is possible to add a Splitgraph engine as a replication client to a production PostgreSQL database, occasionally committing the changes as new Splitgraph images. This is done through PostgreSQL logical replication and has many uses:
+It is possible to add a Splitgraph engine as a [logical replication client](https://www.postgresql.org/docs/current/logical-replication.html) to a production PostgreSQL database, occasionally committing the changes as new Splitgraph images. This has many uses:
 
 - Recording the history of the upstream database for audit purposes
 - Using anonymized production data snapshots for integration testing

--- a/content/docs/0300_ingesting-data/0300_socrata.mdx
+++ b/content/docs/0300_ingesting-data/0300_socrata.mdx
@@ -8,7 +8,7 @@ export const meta = {
 The [Socrata data platform](https://www.tylertech.com/products/socrata) hosts tens of thousands of government datasets. Governments large and small publish data on crime, permits, finance, healthcare, research, performance, and more for citizens to use.
 
 Splitgraph has first-class support for querying Socrata datasets through SQL and using them in
-[Splitfiles](../concepts/splitfiles). The Socrata connector is implemented as a [foreign data wrapper](foreign-data-wrappers/introduction). This allows Splitgraph to also be used as a PostgreSQL-to-Socrata connector. Any PostgreSQL application, client or dashboarding tool can query Socrata datasets through Splitgraph and even run joins on datasets from different Socrata endpoints or between Socrata datasets and Splitgraph images.
+[Splitfiles](../concepts/splitfiles). Support for Socrata is implemented as a [foreign data wrapper](foreign-data-wrappers/introduction). This allows Splitgraph to also be used as a PostgreSQL-to-Socrata connector. Any PostgreSQL application, client or dashboarding tool can query Socrata datasets through Splitgraph and even run joins on datasets from different Socrata endpoints or between Socrata datasets and Splitgraph images.
 
 ## Usage
 
@@ -101,7 +101,7 @@ The result is a list of all bar owners in Chicago with current liquor licenses.
 
 ### Exploring data with DBeaver
 
-The Socrata Discover API in conjunction with Splitgraph's mounting capabilities allows you t explore Socrata data from any SQL client.
+The Socrata Discover API in conjunction with Splitgraph's mounting capabilities allows you to explore Socrata data from any SQL client.
 
 First, mount Socrata open data endpoints for [Chicago, IL](https://data.cityofchicago.org) and [Cambridge, MA](https://data.cambridgema.gov):
 

--- a/content/docs/0500_large-datasets/0300_chunking.mdx
+++ b/content/docs/0500_large-datasets/0300_chunking.mdx
@@ -4,8 +4,8 @@ export const meta = {
 };
 
 Large Splitgraph tables are usually split up into multiple objects. At commit time, new tables in
-an image are chunked up into fragments into 10000 rows by default. This can be changed by passing
-`--chunk-size` to `sgr commit`.
+an image are chunked up into fragments of 10000 rows by default. This can be changed by passing
+`--chunk-size` to `sgr commit` or changing the `SG_COMMIT_CHUNK_SIZE` configuration flag/environment variable.
 
 Chunking is done by primary key. It is also possible to sort data inside a chunk by passing
 `--chunk-sort-keys` to `sgr commit`. This lets [`cstore_fdw`](https://github.com/citusdata/cstore_fdw),

--- a/content/docs/0700_integrating-splitgraph/0450_metabase.mdx
+++ b/content/docs/0700_integrating-splitgraph/0450_metabase.mdx
@@ -47,26 +47,26 @@ $ docker network connect metabase_default splitgraph_engine_default
 
 Go to `localhost:3000` and set up your Metabase account.
 
-![Set up Metabase account](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/metabase/1_initial_setup.png)
+![Set up Metabase account](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/metabase/1_initial_setup.png)
 
 Use `engine` as the database hostname if you're using the Compose file or `splitgraph_engine_default` (or the Docker container name) if you're using `sgr engine`.
 
-![Set up PostgreSQL connection](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/metabase/2_database_setup.png)
+![Set up PostgreSQL connection](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/metabase/2_database_setup.png)
 
 #### Browse Data issue
 
 As discussed, the "Browse Data" functionality currently doesn't work on Splitgraph, since
 Splitgraph schemas contain slashes in them.
 
-![Browse Data dialog](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/metabase/3_browse_data.png)
+![Browse Data dialog](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/metabase/3_browse_data.png)
 
 #### Write SQL
 
 Click on "Write SQL" and select the Splitgraph database that you set up.
 
-![Click on Write SQL](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/metabase/4_write_sql.png)
+![Click on Write SQL](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/metabase/4_write_sql.png)
 
-![Select Splitgraph database](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/metabase/5_select_database.png)
+![Select Splitgraph database](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/metabase/5_select_database.png)
 
 #### Sample datasets and queries
 
@@ -95,7 +95,7 @@ WHERE text ILIKE '%coronavirus%'
 GROUP BY date;
 ```
 
-![Congress Tweets query example](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/metabase/6_congress_tweets.png)
+![Congress Tweets query example](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/metabase/6_congress_tweets.png)
 
 ```sql
 WITH hourly_counts AS (
@@ -109,7 +109,7 @@ WITH hourly_counts AS (
     GROUP BY hour;
 ```
 
-![Congress Tweets query example](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/metabase/7_congress_tweets.png)
+![Congress Tweets query example](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/metabase/7_congress_tweets.png)
 
 ##### Domestic US Flights
 
@@ -130,7 +130,7 @@ GROUP BY origin_airport
 ORDER BY total_passengers DESC;
 ```
 
-![Domestic US flights query example](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/metabase/8_domestic_us_flights.png)
+![Domestic US flights query example](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/metabase/8_domestic_us_flights.png)
 
 ##### 2016 US Election votes
 
@@ -149,7 +149,7 @@ FROM "splitgraph/2016_election".precinct_results
 GROUP BY state_postal;
 ```
 
-![2016 US Election query example](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/metabase/9_us_election.png)
+![2016 US Election query example](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/metabase/9_us_election.png)
 
 ##### Geonames
 
@@ -169,7 +169,7 @@ ORDER BY elevation DESC
 LIMIT 100;
 ```
 
-![Geonames query example](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/metabase/10_geonames.png)
+![Geonames query example](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/metabase/10_geonames.png)
 
 ```sql
 SELECT
@@ -178,7 +178,7 @@ FROM "splitgraph/geonames".all_countries
 WHERE feature_code = 'PPL' AND name = 'Cambridge'
 ```
 
-![Geonames query example](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/metabase/11_geonames.png)
+![Geonames query example](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/metabase/11_geonames.png)
 
 ##### London Wards
 
@@ -203,4 +203,4 @@ SELECT name, ST_Y(centroid) AS lat, ST_X(centroid) AS lon
 FROM ward_centres;
 ```
 
-![London Wards Election query example](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/metabase/12_london_wards.png)
+![London Wards Election query example](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/metabase/12_london_wards.png)

--- a/content/docs/0700_integrating-splitgraph/0500_datagrip.mdx
+++ b/content/docs/0700_integrating-splitgraph/0500_datagrip.mdx
@@ -7,7 +7,7 @@ JetBrains DataGrip can connect to the Splitgraph engine and use it as a data sou
 
 #### Add PostgreSQL data source
 
-![Add PostgreSQL data source](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/datagrip/1-add-postgres-db.png)
+![Add PostgreSQL data source](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/datagrip/1-add-postgres-db.png)
 
 #### Configure PostgreSQL database
 
@@ -17,24 +17,24 @@ Use a JDBC connection string to add the Splitgraph engine to DataGrip:
 jdbc:postgresql://localhost:5432/splitgraph?user=sgr&password=[password]
 ```
 
-![Configure PostgreSQL database](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/datagrip/2-configure-postgres-db.png)
+![Configure PostgreSQL database](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/datagrip/2-configure-postgres-db.png)
 
 #### Missing schemas
 
 By default, DataGrip only shows the "public" schema in the selector. Splitgraph checks data images out into
 schemas with the same name as the repository.
 
-![Splitgraph schemas missing](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/datagrip/3-schemas-missing.png)
+![Splitgraph schemas missing](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/datagrip/3-schemas-missing.png)
 
 To solve this, right click on the database, then go to Tools, Manage Shown Schemas and check "All Schemas".
 
-![Go to Database -> Database Tools -> Manage Shown Schemas](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/datagrip/4-solution-manage-shown-schemas.png)
+![Go to Database -> Database Tools -> Manage Shown Schemas](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/datagrip/4-solution-manage-shown-schemas.png)
 
-![Check All Schemas](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/datagrip/5-check-all-schemas.png)
+![Check All Schemas](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/datagrip/5-check-all-schemas.png)
 
 Your checked-out Splitgraph datasets will appear in the schema selector.
 
-![The checked-out datasets in the schema selector](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/datagrip/6-everything-there-all-good.png)
+![The checked-out datasets in the schema selector](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/datagrip/6-everything-there-all-good.png)
 
 #### Making geospatial queries
 
@@ -65,10 +65,10 @@ SELECT name, gss_code, ST_Transform(ST_SetSRID(geom, 27700), 4326) FROM "splitgr
 
 Toggle geo viewer by pressing gear in bottom right hand side of window.
 
-![Toggle geo viewer by pressing gear in bottom right hand side of window](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/datagrip/7-making-geo-query.png)
+![Toggle geo viewer by pressing gear in bottom right hand side of window](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/datagrip/7-making-geo-query.png)
 
 Use mouse/keyboard to select one or multiple rows containing polygons to plot (select all with Cmd+A / Ctrl+A).
 
-![Select one row](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/datagrip/9-select-one.png)
+![Select one row](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/datagrip/9-select-one.png)
 
-![Select multiple rows](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating_splitgraph/images/datagrip/10-select-multiple.png)
+![Select multiple rows](https://raw.githubusercontent.com/splitgraph/splitgraph.com/master/content/docs/0700_integrating-splitgraph/images/datagrip/10-select-multiple.png)

--- a/content/product/0000_splitgraph/0000_use-cases.mdx
+++ b/content/product/0000_splitgraph/0000_use-cases.mdx
@@ -24,9 +24,19 @@ Since the Splitgraph engine is based on PostgreSQL, it can even be added as a Po
 [logical replication client](/docs/ingesting-data/postgres-replication) and ingest data directly
 from your production database.
 
+### Querying and plotting Socrata data
+
+Splitgraph has [first-class support](/docs/ingesting-data/socrata/) for querying datasets on the
+[Socrata open data platform](https://www.tylertech.com/products/socrata) through SQL and using them
+in [Splitfiles](../concepts/splitfiles). We also maintain a catalog of [almost 20000 open government datasets](/splitgraph/socrata)
+available for immediate querying.
+
+See the [Socrata example](/docs/ingesting-data/socrata/) for a demonstration of exploring a
+Socrata endpoint with [DBeaver](https://dbeaver.io/) and plotting a dataset with [Metabase](https://www.metabase.com/).
+
 ### Sharing and publishing datasets
 
-Much like Git, Splitgraph is decentralized and any Splitgraph engine can act as a remote. Changes
+Much like Git, Splitgraph is decentralized and any Splitgraph engine can act as a [remote](/docs/architecture/splitgraph-remotes). Changes
 pushed to and pulled from other Splitgraph instances are delta compressed, letting you keep your
 dataset's history without sacrificing storage. See the [decentralized demo](/docs/getting-started/decentralized-demo)
 for an introduction to using Splitgraph in a peer-to-peer fashion.

--- a/content/product/0000_splitgraph/0010_motivation.mdx
+++ b/content/product/0000_splitgraph/0010_motivation.mdx
@@ -1,12 +1,29 @@
-import { Box } from "theme-ui";
-
 export const meta = {
   id: "motivation",
   title: "Motivation",
 };
 
-# Motivation
+The motivation behind building Splitgraph is simple: advancements made in the last decade in software
+engineering and operations, as well as existing best practices, are mostly yet to make their way
+to data science and data engineering.
 
-Motivation
+There are currently tens of thousands of open-source **off-the-shelf services and libraries** available,
+most of them well documented and with clear installation instructions. With Docker, those components can be
+packaged into **self-contained images** that can be dropped into any stack with little extra work required.
 
-<Box sx={{color: "red"}}>Hello</Box>
+Instead of server fleets being configured manually, the rise of infrastructure-as-code has meant that
+whole clusters are now defined in **version-controlled definition files** and can be provisioned, scaled and reconfigured
+automatically.
+
+**Versioning and revision control** is something that every software engineer knows about. Every change
+to code is tracked. Software builds are performed on isolated **CI machines**: there's a clear
+build process that avoids the "works on my machine" class of problems.
+
+Finally, good tools that implement all of this **enhance existing abstractions without breaking them**.
+Any compiler, IDE or editor can benefit from Git, Mercurial or SVN without having to be aware of them.
+Any Unix application can be Dockerized and deployed without being recompiled to use Docker version of system calls.
+
+When we started building Splitgraph in 2018, there was nothing around that hit all these points. Things
+are beginning to change and a lot of interesting tools are getting released to help data work. However,
+we still don't feel like any of them completely satisfy our vision. We list applications and services that
+are most similar to Splitgraph on our [Frequently Asked Questions](/docs/getting-started/frequently-asked-questions#why-not-just-use) page.

--- a/content/product/0000_splitgraph/0020_philosophy.mdx
+++ b/content/product/0000_splitgraph/0020_philosophy.mdx
@@ -3,6 +3,57 @@ export const meta = {
   title: "Philosophy",
 };
 
-# Philosophy
+This page summarizes some core ideas that we had in mind when designing Splitgraph.
 
-Philosophy
+### Borrow concepts but don't blindly apply them
+
+Even though we were inspired by those tools a lot when building Splitgraph, we don't like to think
+of Splitgraph as **Git for data or Docker for data**. We think that the work of a data engineer
+or a data scientist is sufficiently different from software engineering that one can't just take an
+existing tool and remap all of its concepts to the problem of working with data.
+
+However, we still think that data can benefit a lot from [tools and best practices](/product/splitgraph/motivation) in software engineering:
+versioning, self-contained artifacts, continuous integration, reproducible builds and the idea of tools that improve existing workflows without breaking them and forcing users to change them.
+
+### Enhance existing abstractions without breaking them
+
+Would Git be a good revision control system if it required every editor or IDE to be
+rewritten to be aware of Git? Would Docker have taken off like it did if Dockerizing an application
+meant recompiling it to use specific system calls?
+
+We think that great tools **enhance existing abstractions without breaking them**. Git enhances the
+abstraction of the filesystem (by adding versioning to it) using the tools provided by the filesystem
+itself (copying files). The result is that anything that uses the filesystem is enhanced by Git without
+needing to be aware of it. Most editors and IDEs have Git integrations but those are not necessary
+for them to benefit from versioning.
+
+Similarly, Docker enhances the abstraction of Linux system calls (by adding isolation to them) using
+the tools provided by Linux itself (cgroups, namespaces, iptables). Applications don't need to be aware
+that they're running in Docker to benefit from containerization.
+
+We were guided by the same principles when building Splitgraph. We tried carefully to not break
+the abstraction of a PostgreSQL table and wire protocol, because doing otherwise would mean throwing
+away a vast existing ecosystem of applications, users, libraries and extensions. This means that
+a lot of **tools that work with PostgreSQL work with Splitgraph out of the box**.
+
+We collect examples of the most interesting ones on the [integrations page](/product/splitgraph/integrations).
+
+### Data as cattle
+
+There is an idea in DevOps of [cattle and pet servers](http://cloudscaling.com/blog/cloud-computing/the-history-of-pets-vs-cattle/). We think that a similar concept can be applied to data in a warehouse and propose a similar test: if it's a disaster that a dataset gets deleted, it's a pet dataset. If it's OK that a dataset gets deleted, then it's a cattle dataset.
+
+**We think that more datasets should be like cattle than like pets**.
+
+Pet datasets are assembled and curated manually over the course of many years. This could be a production database, a mapping table or data in a CRM.
+
+Cattle datasets are clearly defined and have all their dependencies recorded. It should be possible to recreate cattle datasets from pet datasets.
+ In the very extreme, it should be possible to delete all derived tables in a data warehouse and recreate it from scratch.
+
+Here's what we think are the definitions and benefits of cattle data:
+
+  * Datasets are built from self-contained definition files that explicitly enumerate every dependency that is required.
+  * It's possible to experiment with datasets, rebuilding them against data from a different vendor or seeing the impact on the final model of excluding some dataset from a pipeline.
+  * A library of public datasets is available, ready to be referenced and joined to enrich private data.
+  * When research is put into production, it's easy to see where a dataset came from and what it needs. Sometimes, just running the same dataset build process in production is good enough. Similarly to software, this decreases iteration times and prevents having to maintain two separate codebases.
+  * An ETL pipeline can be replayed at any point in time in an isolated environment to debug issues.
+  * If a source dataset becomes "tainted" (for example, because it has personal information), it's easy to see which data it affected and what needs to be rebuilt.

--- a/content/product/0000_splitgraph/0040_integrations.mdx
+++ b/content/product/0000_splitgraph/0040_integrations.mdx
@@ -3,6 +3,33 @@ export const meta = {
   title: "Integrations",
 };
 
-# Motivation
+Any application or extension that works with PostgreSQL can benefit from Splitgraph's data
+packaging, versioning and sharing capabilities. This page summarizes some of the most interesting
+integrations we have found and written explicit examples for.
 
-Integrations
+### Extensions
+
+  * [PostGIS](/docs/integrating-splitgraph/postgis)
+  * [`postgres_fdw`](/docs/ingesting-data/foreign-data-wrappers/load-postgres-tables)
+  * [`mongo_fdw`](/docs/ingesting-data/foreign-data-wrappers/load-mongo-collections)
+  * [`mysql_fdw`](/docs/ingesting-data/foreign-data-wrappers/load-mysql-tables)
+
+### Applications and libraries
+
+  * [Jupyter notebooks](/docs/integrating-splitgraph/jupyter-notebooks)
+  * [PostgREST](/docs/integrating-splitgraph/postgrest)
+  * [dbt](/docs/integrating-splitgraph/dbt)
+  * [Metabase](/docs/integrating-splitgraph/metabase)
+
+### Clients
+
+  * [Datagrip](/docs/integrating-splitgraph/datagrip)
+  * [pgAdmin](/docs/integrating-splitgraph/pgadmin)
+  * [DBeaver, pgcli, others](/docs/integrating-splitgraph/other-clients)
+
+### Data sources
+
+  * [Foreign data wrappers](/docs/ingesting-data/foreign-data-wrappers/introduction)
+  * [CSV files](/docs/ingesting-data/load-csv-files)
+  * [Socrata open data platform](/docs/ingesting-data/socrata)
+  * [PostgreSQL logical replication](/docs/ingesting-data/postgres-replication)

--- a/content/product/0050_data-lifecycle/0000_ingestion.mdx
+++ b/content/product/0050_data-lifecycle/0000_ingestion.mdx
@@ -3,4 +3,50 @@ export const meta = {
   title: "Ingestion",
 };
 
-# Data ingestion
+Since the [Splitgraph engine](/docs/architecture/splitgraph-engine) is also a PostgreSQL instance,
+you can connect to it with any client, including [DataGrip](/docs/integrating-splitgraph/datagrip), [pgAdmin](/docs/integrating-splitgraph/pgadmin) or [other clients like pgcli or DBeaver](/docs/integrating-splitgraph/other-clients)
+to ingest and explore data. Applications can use [any PostgreSQL driver](https://wiki.postgresql.org/wiki/List_of_drivers)
+to write data to Splitgraph and snapshot it as Splitgraph [images](/docs/concepts/images).
+
+However, Splitgraph comes with some features that make data ingestion easier or redundant.
+
+### Foreign Data Wrappers
+
+[Foreign Data Wrappers](/docs/ingesting-data/foreign-data-wrappers/introduction) are a PostgreSQL feature
+that allows users to write a custom handler for any other database or data source. This turns the source into a set of
+foreign tables that act like normal tables and can be queried by any PostgreSQL client.
+
+The [`sgr mount`](/docs/sgr/data-import-export/mount) CLI command takes care of PostgreSQL foreign
+data wrapper boilerplate for you, creating a "mountpoint" on the engine and letting you query
+the remote database directly through Splitgraph, [snapshot it as an image](/docs/sgr/image-management-creation/import)
+or use it in a [Splitfile](/docs/splitfiles/splitfile-import).
+
+Splitgraph comes with with several open-source foreign data wrappers:
+
+   * [`postgres_fdw`](/docs/ingesting-data/foreign-data-wrappers/load-postgres-tables)
+   * [`mongo_fdw`](/docs/ingesting-data/foreign-data-wrappers/load-mongo-collections)
+   * [`mysql_fdw`](/docs/ingesting-data/foreign-data-wrappers/load-mysql-tables)
+
+Splitgraph also comes with [a fork](https://github.com/splitgraph/Multicorn)
+of [Multicorn](https://multicorn.org/), an extension that allows you to write foreign data
+wrappers in Python and add them as [custom mount handlers](/docs/ingesting-data/foreign-data-wrappers/load-mount-handlers) to Splitgraph.
+
+### Layered querying
+
+[Layered querying](/docs/large-datasets/layered-querying) is implemented as a foreign data wrapper.
+It allows any PostgreSQL client to query large remote Splitgraph datasets by downloading just the
+required table regions on the fly, using [bloom filters](/docs/large-datasets/indexing) and other metadata.
+
+In addition, layered querying runs directly against [`cstore_fdw`](/docs/concepts/objects) fragments
+without checking data out, which can sometimes result in faster read performance
+and lower IO load than normal PostgreSQL tables.
+
+### Socrata
+
+Splitgraph has [first-class support](/docs/ingesting-data/socrata/) for querying datasets on the [Socrata open data platform](https://www.tylertech.com/products/socrata) through SQL and using them in [Splitfiles](/docs/concepts/splitfiles).
+
+Support for Socrata is also implemented using a foreign data wrapper. This allows Splitgraph to be used as a PostgreSQL-to-Socrata connector. Any PostgreSQL application, client or dashboarding tool can query Socrata datasets through Splitgraph and even run joins on datasets from different Socrata endpoints or between Socrata datasets and Splitgraph images.
+
+### Replication
+
+It is possible to add a Splitgraph engine as a [logical replication client](https://www.postgresql.org/docs/current/logical-replication.html) to a production PostgreSQL database, occasionally committing the changes as new Splitgraph images. See the [replication guide](/docs/ingesting-data/postgres-replication) for an example.

--- a/content/product/0050_data-lifecycle/0010_storage.mdx
+++ b/content/product/0050_data-lifecycle/0010_storage.mdx
@@ -3,4 +3,38 @@ export const meta = {
   title: "Storage",
 };
 
-# Data storage features
+### Storage format
+
+Behind the scenes, Splitgraph tables are stored as multiple content-addressable, immutable
+[chunks](/docs/concepts/objects) (we also use terms "object" or "fragment").
+
+Splitgraph uses [cstore_fdw](https://github.com/citusdata/cstore_fdw) as its storage backend. `cstore_fdw` is a
+columnar store for PostgreSQL that allows for [superior read performance and low IO load](https://tech.marksblogg.com/billion-nyc-taxi-rides-postgresql.html). Data stored in `cstore_fdw` can take [up to 5x less space](https://github.com/splitgraph/splitgraph/blob/master/examples/benchmarking/benchmarking_real_data.ipynb) than equivalent PostgreSQL tables.
+
+### Delta compression
+
+There's no limitations to how a Splitgraph table is partitioned: it can be represented by one object,
+multiple disjoint objects (responsible for different regions of the table) or multiple objects
+that overlap each other. This allows Splitgraph to store [just the changes](/docs/working-with-data/inspecting-images#example) that were made to a table,
+letting you keep all of your data's history at low storage cost.
+
+Delta compression is optional: if sensitive data made its way into the history, you can always
+[rechunk](/docs/large-datasets/chunking#rechunking-images) your image to delete it.
+
+### Content addressability
+
+Every Splitgraph object is **immutable** and **content-addressable**: the object's ID identifies
+is contents and objects can't change once they have been created. This lets Splitgraph quickly
+determine what needs to be downloaded to bring a [dataset up to date](/docs/sgr/sharing-images/pull) and optimize storage by
+deduplicating data.
+
+### S3 storage
+
+When Splitgraph images are pushed out to [other instances](/docs/getting-started/decentralized-demo), the objects containing the data itself can be uploaded to an S3-compatible storage provider like [MinIO](https://min.io/).
+
+This lets the remote Splitgraph engine to act as a lightweight metadata store, allowing for cheaper
+data warehousing: unused objects can be stored in object storage and only download to the engine
+on demand when they need to be queried.
+
+See the [object storage example](https://github.com/splitgraph/splitgraph/tree/master/examples/push-to-object-storage)
+for more information.

--- a/content/product/0050_data-lifecycle/0020_research.mdx
+++ b/content/product/0050_data-lifecycle/0020_research.mdx
@@ -3,4 +3,32 @@ export const meta = {
   title: "Research",
 };
 
-# Data research
+Splitgraph lets you work on data with your existing tools whilst also introducing [concepts and
+best practices](/product/splitgraph/motivation) from the software engineering discipline.
+
+### Data Versioning
+
+Splitgraph was partially inspired by Git and implements some of Git's most useful functions. You can
+[check out](/docs/sgr/image-management-creation/checkout), [commit](/docs/sgr/image-management-creation/commit),
+[tag](/docs/sgr/image-management-creation/tag), [push](/docs/sgr/sharing-images/push) and [pull](/docs/sgr/sharing-images/pull) Splitgraph datasets just like you would with Git.
+
+Splitgraph's versioning is implemented on top of the SQL standard. Any existing tool can interact
+with a Splitgraph table and benefit from its change tracking capabilities, for example, [dbt](/docs/integrating-splitgraph/dbt), [Jupyter](/docs/integrating-splitgraph/jupyter-notebooks) or
+[Metabase](/docs/integrating-splitgraph/metabase)
+
+The [decentralized demo](/docs/getting-started/decentralized-demo) shows the basics of running Git operations on data.
+
+### `sgr` CLI
+
+The [`sgr` command line client](/docs/architecture/sgr-cli) is the easiest way to manipulate data
+images and manage your [Splitgraph engine](/docs/architecture/splitgraph-engine). It ships as a
+single binary, freeing you from needing to set up a working Python environment, and takes care
+of running the Splitgraph engine in Docker with [`sgr engine`](/docs/sgr/engine-management/engine-add) commands.
+
+### Python Library
+
+Splitgraph is partially written in Python, letting it directly integrate with Python's vast data science
+ecosystem. You can manipulate Splitgraph images and repositories directly from your Python code
+or [Jupyter](https://jupyter.org/) notebook and export Splitgraph data directly to [Pandas](https://pandas.pydata.org/) DataFrames, including using [layered querying](/docs/large-datasets/layered-querying).
+
+See the [Jupyter/scikit-learn](/docs/integrating-splitgraph/jupyter-notebooks) demo for a showcase.

--- a/content/product/0050_data-lifecycle/0030_transformation.mdx
+++ b/content/product/0050_data-lifecycle/0030_transformation.mdx
@@ -3,4 +3,39 @@ export const meta = {
   title: "Transformation",
 };
 
-# Data transformations
+When [Docker](https://www.docker.com/) came around, it revolutionized the way we think about
+services, making it easy for anyone to build, run, deploy and share self-contained filesystem images.
+
+Instead of handcrafting and looking after ["cattle" servers](/product/splitgraph/philosophy#data-as-cattle), Docker let developers define explicitly
+what libraries, code and environment variables their services needed in a single file
+that could be run by anyone to build an image that could run anywhere, in development or production.
+
+When designing Splitgraph, we were partially inspired by the same ideas.
+
+### Splitfiles
+
+[Splitfiles](/docs/concepts/splitfiles) are a declarative language that is used to build Splitgraph
+data images.
+
+Splitfiles let you [build](/docs/sgr/splitfile-execution/build) datasets in a composable, maintable and reproducible way by using [any SQL DDL or DML statement](/docs/splitfiles/splitfile-sql) to express your ideas.
+
+You can reference [other Splitgraph images](/docs/splitfiles/splitfile-import) or other databases directly from the Splitfile and Splitgraph will take care of downloading images and [mounting](/docs/sgr/data-import-export/mount) databases for you, letting you focus on what to do with the data,
+rather than how to acquire it.
+
+### Provenance tracking and caching
+
+Every data image that is built with a Splitfile has its [provenance](/docs/working-with-data/inspecting-provenance) recorded in it, including all images referenced by it.
+
+Provenance tracking lets you know exactly where each table in your warehouse came from and when to [rebuild](/docs/sgr/splitfile-execution/rebuild) it.
+
+When the time comes to productionize some research, you can use provenance tracking to know which data feeds
+you need to purchase or whether you can use use the same Splitfile to build the data in production.
+
+### Extract, transform, transform
+
+We envision Splitfiles as a replacement for ETL pipelines.
+
+Splitfiles free you from having to run your transformations as processes that move data between tables
+in a single data warehouse and instead allow you to treat transformations as pure functions between isolated, self-contained data images. Any transformation can be replayed at any point in time, helping you debug your data pipeline and easily backfill fixes to historical data.
+
+To get started with Splitfiles, you can follow the [five-minute demo](/docs/getting-started/five-minute-demo) that will take you through the basics of building and publishing a dataset on Splitgraph Cloud, complete with provenance tracking and an automatic OpenAPI-compatible REST API. Alternatively, you can take a look at [sample Splitfiles](https://github.com/splitgraph/splitgraph/tree/master/examples/sample_splitfiles) on our GitHub.

--- a/design/Layout/Sidebar/SidebarLabel.js
+++ b/design/Layout/Sidebar/SidebarLabel.js
@@ -76,7 +76,7 @@ const getHardcodedDepthStyles = (maxHardCodedDepth = 10) => {
     depthStyles.Vertical[`.${ClassNames.Depth(depth)}`] = {
       paddingLeft: `${paddingLeft}rem`,
       marginLeft: `${marginLeft}rem`,
-      paddingRight: depth >= 1 ? "2rem" : `${depth * 2}rem`,
+      paddingRight: depth >= 1 ? "1rem" : `${depth}rem`,
 
       paddingLeft:
         depth >= 1 ? `${marginLeft + paddingLeft}rem !important` : "initial",

--- a/docs/components/Footer/Footer.tsx
+++ b/docs/components/Footer/Footer.tsx
@@ -194,10 +194,7 @@ const Footer = ({ footerVariant = "dark", extraStyle = {} }: IFooterProps) => {
 
       <Box className="footer-copyright-row">
         <Box className="footer-section">
-          Splitgraph Limited, Registered in England and Wales no.{" "}
-          <a href="https://beta.companieshouse.gov.uk/company/11657324">
-            11657324
-          </a>
+          Splitgraph Limited, Registered in England and Wales no. 11657324
           <br />
           <br />
           <Box sx={{ display: "flex", alignItems: "center" }}>

--- a/docs/pages/index.js
+++ b/docs/pages/index.js
@@ -301,6 +301,9 @@ const featureSectionStyle = {
     h2: {
       margin: 0,
     },
+    // TODO I added this to get line breaks in feature subheadings but it broke the layout
+    //   (no longer vertically centred)
+    flexDirection: "column",
   },
   ul: {
     width: ["inherit", "inherit", "50%"],
@@ -529,7 +532,7 @@ const LandingPage = () => {
               while keeping your existing workflows and benefitting from the
               Postgres ecosystem.
             </p>
-            <Link href="/docs/integrating-splitgraph/dbt">
+            <Link href="/product/splitgraph/motivation">
               See examples of common integrations
             </Link>
           </Box>
@@ -637,6 +640,9 @@ const LandingPage = () => {
       <section className="lp-feature-section" sx={featureSectionStyle}>
         <Box className="feature-section-header">
           <h2>Ingestion</h2>
+          <Link href="/product/data-lifecycle/ingestion">
+            <p>Go beyond ETL and query other databases directly from Splitgraph.</p>
+          </Link>
         </Box>
 
         <ul>
@@ -714,6 +720,9 @@ const LandingPage = () => {
       <section className="lp-feature-section" sx={featureSectionStyle}>
         <Box className="feature-section-header">
           <h2>Storage</h2>
+          <Link href="/product/data-lifecycle/storage">
+            <p>Save on storage costs with a columnar format and delta compression.</p>
+          </Link>
         </Box>
 
         <ul>
@@ -787,6 +796,9 @@ const LandingPage = () => {
       <section className="lp-feature-section" sx={featureSectionStyle}>
         <Box className="feature-section-header">
           <h2>Research and Reporting</h2>
+          <Link href="/product/data-lifecycle/research">
+            <p>Work on data with familiar tools and paradigms.</p>
+          </Link>
         </Box>
 
         <ul>
@@ -875,6 +887,9 @@ const LandingPage = () => {
       <section className="lp-feature-section" sx={featureSectionStyle}>
         <Box className="feature-section-header">
           <h2>Transformations</h2>
+          <Link href="/product/data-lifecycle/transformation">
+            Build datasets in a composable and maintainable way, suitable for research or production.
+          </Link>
         </Box>
 
         <ul>
@@ -975,6 +990,7 @@ const LandingPage = () => {
       <section className="lp-feature-section" sx={featureSectionStyle}>
         <Box className="feature-section-header">
           <h2>Sharing</h2>
+          <p>Go beyond one machine and collaborate on data with others.</p>
         </Box>
 
         <ul>
@@ -1129,11 +1145,10 @@ const LandingPage = () => {
             />
             <h3>Treat your data like cattle</h3>
             <p>
-              Stop wrangling data, and start wrangling databases. Use Splitgraph
-              to escape the fragility of spaghetti ETL code and deploy
-              confidently to production.
+              Stop treating your datasets like pets. Use Splitgraph to gain confidence
+              about where data in your warehouse came from and how to rebuild it from scratch.
             </p>
-            <Link href="#">Read about our philosophy</Link>
+            <Link href="/product/splitgraph/philosophy#data-as-cattle">Read about our philosophy</Link>
           </Box>
         </Box>
       </section>

--- a/docs/pages/index.js
+++ b/docs/pages/index.js
@@ -532,7 +532,7 @@ const LandingPage = () => {
               while keeping your existing workflows and benefitting from the
               Postgres ecosystem.
             </p>
-            <Link href="/product/splitgraph/motivation">
+            <Link href="/product/splitgraph/integrations">
               See examples of common integrations
             </Link>
           </Box>

--- a/templaters/layouts/withHolyGrailLayout.js
+++ b/templaters/layouts/withHolyGrailLayout.js
@@ -100,7 +100,7 @@ const withHolyGrailLayout = ({
             }
 
             ${!renderTOC && "nav.toc { display: none; }"}
-        `.replace(/\s\s+/g, " ").replace(/\/\*.*\*\//g, ""),
+        `.replace(/\s\s+/g, " ").replace(/\/\*(?!\*\/)*\*\//g, ""),
             },
           ]}
         />

--- a/templaters/layouts/withHolyGrailLayout.js
+++ b/templaters/layouts/withHolyGrailLayout.js
@@ -100,7 +100,7 @@ const withHolyGrailLayout = ({
             }
 
             ${!renderTOC && "nav.toc { display: none; }"}
-        `.replace(/\s/g, ""),
+        `.replace(/\s\s+/g, " ").replace(/\/\*.*\*\//g, ""),
             },
           ]}
         />


### PR DESCRIPTION
Sections:
  * Lifecycle -- ingestion, storage, research, transformation
  * Splitgraph -- use cases, motivation, philosophy, integrations
  * Team -- list people, no bios yet (apart from PHB)
  * Contact

Broken:
  * `flexDirection: "column",` (line 306 in index.js) -- added this to get wrapping for subheaders in data lifecycle
  * actual data lifecycle subheadings have links to relevant pages but they don't have styles
  * footer (probably anything else that uses this) has `min(calc(...))` CSS for padding; `min` is not supported on FF <75. As an alternative, I tried `calc((100vw - 100ch)/2 + 4rem)` for padding and at least in the footer it seems to look fine until the `40em` media query takes over but I didn't apply this fix.

Non-writing changes:
  * Image links use dashes instead of underscores
  * Remove link to Companies House from footer
  * Decrease padding in TOC to be in steps of 1rem; max out at 1rem
  * Fix TOC at top of text not disappearing on wide screens (overzealous whitespace stripping in header CSS)