### PR TITLE
Add docsearch to docs website (algolia docsearch)

### DIFF
--- a/.github/workflows/build_and_deploy_preview.yml
+++ b/.github/workflows/build_and_deploy_preview.yml
@@ -22,6 +22,8 @@ jobs:
         env:
           YARN_CACHE_FOLDER: /home/runner/yarn-cache
       - run: ./.ci/build.sh
+        env:
+          DOCSEARCH_PUBLIC_CLIENT_API_KEY: ${{ secrets.DOCSEARCH_PUBLIC_CLIENT_API_KEY }}
       - run: ./.ci/deploy_preview.sh
         env:
           NOW_TOKEN: ${{ secrets.NOW_TOKEN }}

--- a/docs/components/DocSearch/DocSearch.tsx
+++ b/docs/components/DocSearch/DocSearch.tsx
@@ -1,0 +1,137 @@
+// @jsx jsx
+// @ts-ignore
+import { jsx, Box } from "theme-ui";
+import * as React from "react";
+import { Helmet } from "react-helmet";
+
+import { searchIconURI } from "@splitgraph/tdesign";
+
+export interface IDocSearchProps {}
+
+const DOCSEARCH_JS_URL = process.env.DOCSEARCH_JS_URL;
+const DOCSEARCH_CSS_URL = process.env.DOCSEARCH_CSS_URL;
+const DOCSEARCH_PUBLIC_CLIENT_API_KEY =
+  process.env.DOCSEARCH_PUBLIC_CLIENT_API_KEY;
+const DOCSEARCH_INDEX_NAME = process.env.DOCSEARCH_INDEX_NAME;
+
+export interface IWindowWithDocSearch extends Window {
+  docsearch: (opts: {
+    apiKey: string;
+    indexName: string;
+    inputSelector: string;
+    debug?: boolean;
+  }) => void;
+}
+
+const mountBodyScript = ({ onLoad }) => {
+  const srcURL = DOCSEARCH_JS_URL;
+
+  const bodyScriptElement = document.createElement("script");
+  const bodyRefElement = document.getElementsByTagName("body")[0];
+  bodyScriptElement.type = "text/javascript";
+  bodyScriptElement.async = true;
+  bodyScriptElement.defer = true;
+  bodyScriptElement.src = srcURL;
+
+  // Once the script is ready, call the onLoad() closure to setState in the component
+  bodyScriptElement.onload = () => onLoad();
+
+  // TODO: Should maybe add a check to see if it already exists,
+  //       but not necessary as long as caller checks if window.docsearch exists
+  bodyRefElement.appendChild(bodyScriptElement);
+};
+
+const DocSearch = ({}: IDocSearchProps) => {
+  const [enabled, setEnabled] = React.useState(true);
+
+  const [windowReady, setWindowReady] = React.useState(false);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") {
+      setWindowReady(false);
+      return;
+    }
+
+    if (
+      (window as IWindowWithDocSearch & typeof globalThis).docsearch ||
+      windowReady
+    ) {
+      console.log("✔︎ docsearch already loaded");
+      setWindowReady(true);
+      return;
+    }
+
+    mountBodyScript({
+      onLoad: () => {
+        setWindowReady(true);
+      },
+    });
+  }, []);
+
+  React.useEffect(() => {
+    if (!windowReady) {
+      return;
+    }
+
+    const docsearch = (window as IWindowWithDocSearch & typeof globalThis)
+      ?.docsearch;
+
+    if (!docsearch) {
+      console.warn("window.docsearch does not exist");
+      return;
+    }
+
+    docsearch({
+      apiKey: DOCSEARCH_PUBLIC_CLIENT_API_KEY,
+      indexName: DOCSEARCH_INDEX_NAME,
+      inputSelector: "#algolia-doc-search",
+      debug: false,
+    });
+
+    console.log("✔︎ docsearch ready");
+
+    setEnabled(true);
+  }, [windowReady]);
+
+  const style = {
+    display: ["none", "none", "inline"],
+    marginRight: "2rem",
+    form: {
+      display: "inline",
+    },
+    input: {
+      background: `url(${searchIconURI}) no-repeat 8px 50%`,
+      paddingLeft: "3em",
+      paddingTop: "0.5em",
+      paddingBottom: "0.5em",
+      backgroundColor: "white",
+      color: "heavy",
+      border: "1px solid gray",
+      // color: "gray",
+      // min 16px font size so iOS does not zoom on focus
+      fontSize: ["16px", "inherit", "inherit"],
+    },
+  };
+
+  return enabled ? (
+    <>
+      <Helmet>
+        <link rel="stylesheet" href={DOCSEARCH_CSS_URL} />
+      </Helmet>
+      <Box sx={style}>
+        <form>
+          <input
+            type="search"
+            placeholder="Search Docs..."
+            aria-label="Search Docs"
+            id="algolia-doc-search"
+          />
+        </form>
+      </Box>
+    </>
+  ) : (
+    <span>&nbsp;</span>
+  );
+};
+
+export default DocSearch;

--- a/docs/components/DocSearch/index.tsx
+++ b/docs/components/DocSearch/index.tsx
@@ -1,0 +1,3 @@
+import DocSearch from './DocSearch';
+export { DocSearch };
+

--- a/docs/components/index.tsx
+++ b/docs/components/index.tsx
@@ -14,3 +14,5 @@ export { BlogPost } from "./BlogPost";
 export { Breadcrumbs } from "./Breadcrumbs";
 export { RSSMetaTag } from './RSSMetaTag';
 
+export { DocSearch } from './DocSearch';
+

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -40,6 +40,16 @@ const nextConfig = {
     MATOMO_JS_FILE: "",
     MATOMO_PHP_FILE: "",
     MATOMO_SITE_ID: "1",
+
+    DOCSEARCH_JS_URL:
+      process.env.DOCSEARCH_JS_URL ||
+      "https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js",
+    DOCSEARCH_CSS_URL:
+      process.env.DOCSEARCH_CSS_URL ||
+      "https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css",
+    DOCSEARCH_PUBLIC_CLIENT_API_KEY:
+      process.env.DOCSEARCH_PUBLIC_CLIENT_API_KEY,
+    DOCSEARCH_INDEX_NAME: process.env.DOCSEARCH_INDEX_NAME || "splitgraph",
   },
   resolve: {
     alias: aliasConfig,

--- a/templaters/layouts/withDocsLayout.js
+++ b/templaters/layouts/withDocsLayout.js
@@ -1,6 +1,7 @@
 // @jsx jsx
 import { jsx } from "theme-ui";
 import React from "react";
+import { DocSearch } from "@splitgraph/docs/components";
 import withHolyGrailLayout from "./withHolyGrailLayout";
 
 const getDocsSEO = ({ currentURL, meta, SEO_BASE_URL }) => {
@@ -31,4 +32,5 @@ export default withHolyGrailLayout({
   titleTemplate: "%s - Documentation | Splitgraph",
   getSEO: getDocsSEO,
   renderDocsHeaderLink: false,
+  middleHeader: <DocSearch />,
 });

--- a/templaters/layouts/withHolyGrailLayout.js
+++ b/templaters/layouts/withHolyGrailLayout.js
@@ -20,7 +20,7 @@ import {
 } from "@splitgraph/design";
 
 import { BaseLayout } from "@splitgraph/design/Layout";
-import { Link } from "@splitgraph/docs/components";
+import { Link, DocSearch } from "@splitgraph/docs/components";
 
 import { Footer } from "@splitgraph/tdesign";
 
@@ -33,6 +33,7 @@ const withHolyGrailLayout = ({
   renderTitleHeading = true,
   renderInterPageNav = true,
   renderDocsHeaderLink = true,
+  middleHeader = null,
   getSEO = ({ currentURL, meta, contentTree, SEO_BASE_URL }) => ({}),
 }) => ({ MdxPage, meta = {}, contentTree }) => {
   const HolyGrailSEO = ({ currentURL }) => {
@@ -132,7 +133,8 @@ const withHolyGrailLayout = ({
                 Splitgraph
               </a>
             </Box>
-            <Box sx={{ color: "muted" }}>
+            <Box sx={{ color: "muted", display: "flex", alignItems: "center" }}>
+              {middleHeader}
               <Link href="/explore">Explore Data</Link>
               {renderDocsHeaderLink ? (
                 <>


### PR DESCRIPTION
Components:

- Add support for rendering "middle header" in `<HolyGrailLayout>`
- Render "middle header" containing `<DocSearch />` in `withDocsLayout`
- Add `<DocSearch />` component including async loading
  of scripts for docsearch from algolia

  Configuration:

- (Out of band) Add "secret" to GH actions: `DOCSEARCH_PUBLIC_CLIENT_API_KEY`
- Add new env vars to configure during build time
- Docsearch required env var: `DOCSEARCH_PUBLIC_CLIENT_API_KEY`
- Add optional env var for configuring URL of docsearch JS and CSS files
  (use jsdelivr CDN for now, but we should bundle these)

Todo:

- Submit PR in algolia repo to Splitgraph config, to exclude URLs matching old versions