### PR TITLE
Add blog author link to team page

### DIFF
--- a/design/Form/Input.js
+++ b/design/Form/Input.js
@@ -26,12 +26,19 @@ export default React.forwardRef(
         sx={{
           width: 200,
           borderColor: error ? "danger" : "initial",
-          ...sx
+          ...sx,
         }}
         {...rest}
       />
 
-      <Box mt={2}>
+      <Box
+        mt={2}
+        sx={{
+          ".danger-text,.warning-text,.success-text": {
+            maxWidth: "fit-content",
+          },
+        }}
+      >
         {validating ? (
           <MutedText>&#9850; {validatingText} ...</MutedText>
         ) : error ? (

--- a/design/Layout/BaseLayout/BaseLayout.js
+++ b/design/Layout/BaseLayout/BaseLayout.js
@@ -3,16 +3,7 @@ import defaultTheme from "../../themes/defaultTheme";
 import { ThemeProvider } from "theme-ui";
 
 const BaseLayout = ({ children }) => {
-  return (
-    <ThemeProvider theme={defaultTheme}>
-      {children}
-      {/* <style jsx global>{`
-        body {
-          font-family: "Open Sans", sans-serif;
-        }
-      `}</style> */}
-    </ThemeProvider>
-  );
+  return <ThemeProvider theme={defaultTheme}>{children}</ThemeProvider>;
 };
 
 export default BaseLayout;

--- a/design/Text/SuccessText.js
+++ b/design/Text/SuccessText.js
@@ -4,8 +4,9 @@ export default ({ children, sx = {}, ...rest }) => (
   <Text
     sx={{
       color: "success",
-      ...sx
+      ...sx,
     }}
+    className="success-text"
     {...rest}
   >
     {children}

--- a/design/Text/WarningText.js
+++ b/design/Text/WarningText.js
@@ -4,9 +4,10 @@ export default ({ children, sx = {}, ...rest }) => (
   <Text
     sx={{
       color: "warning",
-      ...sx
+      ...sx,
     }}
     {...rest}
+    className="warning-text"
   >
     {children}
   </Text>

--- a/design/css/base.css
+++ b/design/css/base.css
@@ -8,7 +8,6 @@ body {
   margin: 0;
   border: 0;
 
-  /* font-family: "Open Sans", sans-serif; */
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
     sans-serif, Apple Color Emoji, Segoe UI Emoji;
 

--- a/docs/components/BlogPost/BlogPostHeaderMetadata/BlogPostHeaderMetadata.tsx
+++ b/docs/components/BlogPost/BlogPostHeaderMetadata/BlogPostHeaderMetadata.tsx
@@ -3,6 +3,7 @@
 import { jsx, Box, SystemStyleObject } from "theme-ui";
 import * as React from "react";
 
+import { Link } from "../../Link";
 import { IBlogPostMetadata } from "../../BlogPostItem";
 
 import formatDate from "../formatDate";
@@ -23,7 +24,6 @@ const containerStyle = {
     display: "flex",
     flexDirection: "row",
     justifyContent: "space-between",
-    opacity: "0.5",
   },
   ".metadata-container": {
     display: "flex",
@@ -32,6 +32,10 @@ const containerStyle = {
   ".metadata-label": {
     textTransform: "uppercase",
     fontSize: "small",
+    opacity: "0.5",
+  },
+  ".date-value": {
+    opacity: "0.5",
   },
 } as SystemStyleObject;
 
@@ -54,7 +58,9 @@ const BlogPostHeaderMetadata = ({
       <Box className="bot-row">
         <Box className="metadata-container authors-container">
           <span className="metadata-label authors-label">{authorsLabel}</span>
-          <span className="authors-value">{authorsValue}</span>
+          <Link className="authors-value" href="/about/company/team">
+            {authorsValue}
+          </Link>
         </Box>
         <Box
           className="metadata-container date-container"


### PR DESCRIPTION
In blog post, render blog author as link to team page instead of text

Also includes some `@splitgraph/design` library improvements that don't affect the splitgraph.com site