### PR TITLE
Docs/mount handler refactor

### DIFF
--- a/content/about/0000_company/0010_contact.mdx
+++ b/content/about/0000_company/0010_contact.mdx
@@ -7,4 +7,4 @@ Splitgraph Limited is a company registered in England and Wales (no. 11657324) a
 
 **Press inquiries**: [press@splitgraph.com](mailto:press@splitgraph.com)
 
-**All other inquiries**: [support@splitgraph.com](mailto:support@spligraph.com)
+**All other inquiries**: [support@splitgraph.com](mailto:support@splitgraph.com)

--- a/content/docs/0300_ingesting-data/0300_foreign-data-wrappers/0200_load-mongo-collections.mdx
+++ b/content/docs/0300_ingesting-data/0300_foreign-data-wrappers/0200_load-mongo-collections.mdx
@@ -10,9 +10,8 @@ $ sgr mount mongo_fdw example/mongo \\
     -c username:password@mongo_host:27017 -o @- <<EOF
 {
     "example_table": {
-        "db": "example_db",
-        "coll": "example_collection",
-        "schema": {"column_1": "text", "column_2": "numeric"}
+        "schema": {"column_1": "text", "column_2": "numeric"},
+        "options": {"db": "example_db", "coll": "example_collection"}
     }
 }
 EOF

--- a/content/docs/0300_ingesting-data/0300_foreign-data-wrappers/0300_load-postgres-tables.mdx
+++ b/content/docs/0300_ingesting-data/0300_foreign-data-wrappers/0300_load-postgres-tables.mdx
@@ -24,8 +24,10 @@ You can also pass a dictionary of tables and their schema as `tables`. This will
 {
     "tables": {
         "table_1": {
-            "col_1": "integer",
-            "col_2": "text"
+            "schema": {
+                "col_1": "integer",
+                "col_2": "text"
+            }
         }
     }
 }

--- a/content/docs/0300_ingesting-data/0300_foreign-data-wrappers/0400_load-mysql-tables.mdx
+++ b/content/docs/0300_ingesting-data/0300_foreign-data-wrappers/0400_load-mysql-tables.mdx
@@ -9,9 +9,8 @@ To mount a MySQL database into the Splitgraph engine using [`mysql_fdw`](https:/
 $ sgr mount mysql_fdw local_schema -c username:password@host:port -o@- <<EOF
 {
     "remote_schema": "remote_schema",
-    "tables": ["table_1"],
+    "tables": ["table_1"]
 }
-
 ```
 
 This will mount a MySQL schema `remote_schema` into a local schema `schema_name` on the
@@ -26,8 +25,10 @@ You can also pass a dictionary of tables and their schema as `tables`. This will
 {
     "tables": {
         "table_1": {
-            "col_1": "integer",
-            "col_2": "text"
+            "schema": {
+                "col_1": "integer",
+                "col_2": "text"
+            }
         }
     }
 }

--- a/content/docs/0300_ingesting-data/0300_foreign-data-wrappers/0450_load-elasticsearch-index.mdx
+++ b/content/docs/0300_ingesting-data/0300_foreign-data-wrappers/0450_load-elasticsearch-index.mdx
@@ -17,9 +17,11 @@ $ sgr mount elasticsearch -c elasticsearch:9200 -o@- <<EOF
             "col_1": "text",
             "col_2": "boolean",
           },
-          "index": "index-pattern*",
-          "rowid_column": "id",
-          "query_column": "query",
+          "options": {
+              "index": "index-pattern*",
+              "rowid_column": "id",
+              "query_column": "query"
+          }
         }
       }
     }

--- a/content/docs/0300_ingesting-data/0300_foreign-data-wrappers/0500_load-mount-handlers.mdx
+++ b/content/docs/0300_ingesting-data/0300_foreign-data-wrappers/0500_load-mount-handlers.mdx
@@ -6,76 +6,15 @@ export const meta = {
 To mount a custom database into your Splitgraph engine, you have to do three things:
 
 - Install the foreign data wrapper into the engine (either using PGXN or compiling the wrapper by yourself)
-- Write a Python function that, when invoked, will create the required mountpoint on the engine and initialize
-  the remote foreign data wrapper. For an example, see `mount_postgres` in `splitgraph.hooks.mount_handlers`.
+- Write a Python class deriving from `ForeignDataWrapperDataSource` that defines the FDW's class
+ and how command line options map to the FDW's own options. For an example, see `PostgreSQLDataSource` in `splitgraph.hooks.data_source`.
 - Register the handler in your `.sgconfig` file:
 
 ```ini
 [mount_handlers]
-handler_name=your.handler.module.handler_function
+handler_name=your.handler.module.HandlerClass
 ```
 
-Registering the handler in such a way will also parse its function signature and docstring, adding the handler automatically to the `sgr` client as a subcommand, as well as making it available to be used in Splitfiles.
+Registering the handler in such a way will also use make it available in the `sgr` client as an `sgr mount` subcommand, as well as make it available to be used in Splitfiles.
 
-For example, the `mount_postgres` function:
-
-```py
-def mount_postgres(mountpoint, server, port, username, password, dbname, remote_schema, tables=[]):
-    """
-    Mount a Postgres database.
-
-    Mounts a schema on a remote Postgres database as a set of foreign tables locally.
-    \b
-
-    :param mountpoint: Schema to mount the remote into.
-    :param server: Database hostname.
-    :param port: Port the Postgres server is running on.
-    :param username: A read-only user that the database will be accessed as.
-    :param password: Password for the read-only user.
-    :param dbname: Remote database name.
-    :param remote_schema: Remote schema name.
-    :param tables: Tables to mount (default all).
-    """
-    engine = get_engine()
-    logging.info("Importing foreign Postgres schema...")
-
-    # Name foreign servers based on their targets so that we can reuse them.
-    server_id = '%s_%s_%s_server' % (server, str(port), dbname)
-    init_fdw(engine, server_id, "postgres_fdw", {'host': server, 'port': str(port), 'dbname': dbname},
-             {'user': username, 'password': password}, overwrite=False)
-
-    engine.run_sql(SQL("CREATE SCHEMA {}").format(Identifier(mountpoint)))
-
-    # Construct a query: import schema limit to (%s, %s, ...) from server mountpoint_server into mountpoint
-    query = "IMPORT FOREIGN SCHEMA {} "
-    if tables:
-        query += "LIMIT TO (" + ",".join("%s" for _ in tables) + ") "
-    query += "FROM SERVER {} INTO {}"
-    engine.run_sql(SQL(query).format(Identifier(remote_schema), Identifier(server_id),
-                                     Identifier(mountpoint)), tables)
-```
-
-gets made available in the `sgr` client with this help message:
-
-```bash
-$ sgr mount postgres_fdw --help
-Usage: sgr mount postgres_fdw [OPTIONS] SCHEMA
-
-      Mount a Postgres database.
-
-      Mounts a schema on a remote Postgres database as a set of foreign
-      tables locally.
-
-Options:
-  -c, --connection TEXT       Connection string in the form
-                              username:password@server:port
-  -o, --handler-options TEXT  JSON-encoded dictionary of handler options:
-                              dbname: Remote database name.
-                              remote_schema:
-                              Remote schema name.
-                              tables: Tables to mount
-                              (default all).
-  --help                      Show this message and exit.
-```
-
-The connection string gets parsed and passed to the mount handler as `server`, `port`, `username` and `password` parameters. The remaining options are converted from a JSON dictionary and passed to the handler as extra kwargs.
+For an end-to-end example of a custom mount handler querying the Firebase Hacker News API, see [Splitgraph's GitHub repository](https://github.com/splitgraph/splitgraph/tree/master/examples/custom_fdw).


### PR DESCRIPTION
Update docs to use a newer mount handler syntax (now on splitgraph/splitgraph master) and fix a typo