### PR TITLE
Add note about support in R

### DIFF
--- a/content/docs/0900_splitgraph-cloud/0400_data-delivery-network.mdx
+++ b/content/docs/0900_splitgraph-cloud/0400_data-delivery-network.mdx
@@ -150,6 +150,10 @@ SQL queries work, allowing you to use Splitgraph data in your Metabase dashboard
 
 Introspection query interception doesn't work on DataGrip (you will see an empty tree in the sidebar) but you can still run all SQL queries.
 
+### R, RStudio
+
+The `RPostgres` driver does not support connecting to clients which have disabled prepared statements (see the [GitHub issue](https://github.com/r-dbi/RPostgres/issues/185) for details) so it is recommended that you use the `RPostgreSQL` driver instead.
+
 ## Roadmap
 
 We aim to make the SQL endpoint the core of Splitgraph's offering, moving us to being a "data delivery network": a single endpoint giving you access to all your data with extra services like caching, granular access control, auditing, query firewalling or performance optimization.


### PR DESCRIPTION
It was a bit of a battle to connect to the Splitgraph DDN in R due to the fact that prepared statements are disabled, SSL is required, and there are forward-slashes in schema names.

I eventually hit upon the following code:

```R
library(DBI)
library(RPostgreSQL)
library(dbplyr)

connection <- dbConnect(
  dbDriver("PostgreSQL"),
  host = "data.splitgraph.com",
  dbname = "ddn",
  user = "...",
  password = "..."
)
```

In this PR I added a gotcha about the RPostgres library, which is the more popular library for connecting to PostgreSQL databases in R. However, I didn't write anything about the way to quote the schema names, as I wasn't sure if it belonged there...
