### PR TITLE
Restore default scrollbar

### DIFF
--- a/design/css/base.css
+++ b/design/css/base.css
@@ -1,7 +1,3 @@
-* {
-  scrollbar-width: thin;
-}
-
 html,
 body {
   padding: 0;


### PR DESCRIPTION
Some pages of the document are very long and the scrollbar is appreciated. Nothing warrants a thinner scrollbar on splitgraph.com than everywhere else, it just hurts accessibility with no benefits.