### PR TITLE
Add CI notifications and make build step opt-in

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -3,11 +3,25 @@
 CI_DIR="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 SPLITGRAPH_DIR="$CI_DIR/.."
 
-pushd "$SPLITGRAPH_DIR" \
-    && mv tsconfig.ci.json tsconfig.json \
-    && yarn typecheck-and-build \
-    && cp "$SPLITGRAPH_DIR"/docs/proxyDirectories.txt "$SPLITGRAPH_DIR"/docs/out/proxyDirectories.txt \
-    && echo "Build successful" \
-    && exit 0
+pushd "$SPLITGRAPH_DIR"
+
+if test -f tsconfig.ci.json ; then
+    >&2 echo "Build error: tsconfig.ci.json still exists, which means typecheck did not happen"
+    popd
+    exit 1
+fi
+
+if test ! -d dist ; then
+    >&2 echo "Build error: missing dist folder. Did typecheck pass?"
+    popd
+    exit 1
+fi
+
+echo "Temporary quick build" && popd && exit 0
+
+# yarn build \
+#     && cp "$SPLITGRAPH_DIR"/docs/proxyDirectories.txt "$SPLITGRAPH_DIR"/docs/out/proxyDirectories.txt \
+#     && echo "Build successful" \
+#     && exit 0
 
 exit 1

--- a/.ci/fail_deliberately.sh
+++ b/.ci/fail_deliberately.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo "Failing deliberately from within a script"
+
+exit 1

--- a/.ci/notify.sh
+++ b/.ci/notify.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+exit_with_err() {
+  echo >&2 "Fatal error: $1"; exit 1;
+}
+
+test -z "$NOTIFY_WEBHOOK"     && { exit_with_err "Missing NOTIFY_WEBHOOK"; }
+command -v jq >/dev/null 2>&1 || { exit_with_err "Missing jq"; }
+type jq >/dev/null 2>&1       || { exit_with_err "Missing jq"; }
+hash jq 2>/dev/null           || { exit_with_err "Missing jq"; }
+
+if test -f "$1" ; then
+    message_body="$(cat "$1")"
+elif test -z "$1" ; then
+    message_body "Got notify.sh without a message_body"
+else
+    message_body="$*"
+fi
+
+
+touch preamble.txt
+message="$(printf "%s%s%s\n\n%s" \
+           "$JOB_ICON" \
+           "$(test -n "$JOB_ICON" && echo -n "&emsp;")" \
+           "$(cat preamble.txt)" \
+           "$message_body" \
+       )"
+
+set -e
+echo "Send notification..."
+
+echo "---> message"
+echo "$message"
+echo "----"
+
+# Merge $message into the payload object (currently no other keys)
+PAYLOAD='{
+}'
+
+body=$(echo $PAYLOAD | jq -c --arg text "$message" '.text = $text')
+
+echo "---> preamble"
+cat preamble.txt
+echo "----"
+
+echo "---> body"
+echo "$body"
+echo "----"
+
+curl -i -X POST -H 'Content-Type: application/json' \
+    -d "$body" "$NOTIFY_WEBHOOK"

--- a/.ci/typecheck.sh
+++ b/.ci/typecheck.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+CI_DIR="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
+SPLITGRAPH_DIR="$CI_DIR/.."
+
+pushd "$SPLITGRAPH_DIR" \
+    && mv tsconfig.ci.json tsconfig.json \
+    && yarn typecheck \
+    && echo "Typecheck successful" \
+    && exit 0
+
+exit 1

--- a/.github/actions/notifier-complete/action.yml
+++ b/.github/actions/notifier-complete/action.yml
@@ -1,0 +1,113 @@
+name: 'Notifier Complete'
+description: 'Stop the timer and create the notification'
+inputs:
+  job_status:
+    description: 'Workflow should pass job.status to this action with job-status'
+    default: 'failure'
+
+  parent_steps:
+    description: 'Parent step context'
+    default: '{}'
+
+  notification_body_file:
+    description: The file where to write the body of the notification
+    default: notify.txt
+
+  # For emoji text (for job status and step failure(s))
+  ICON_SUCCESS:
+    default: ':white_check_mark:'
+  ICON_FAIL:
+    default: ':skull_and_crossbones:'
+  ICON_CANCEL:
+    default: ':heavy_multiplication_x:'
+  ICON_UNKNOWN:
+    default: ':grey_question:'
+
+  # Unicode icons (for deemphasized statuses)
+  UNI_SUCCESS:
+    default: '&#10003;'
+  UNI_CANCEL:
+    default: '&#88;'
+  UNI_SKIP:
+    default: '&#8213;'
+  UNI_UNKNOWN:
+    default: '&#63;'
+runs:
+  using: "composite"
+  steps:
+    - name: Dump steps context
+      shell: bash
+      env:
+        STEPS_CONTEXT: ${{ inputs.parent_steps }}
+      run: echo "$STEPS_CONTEXT"
+
+    - name: Stop Timer
+      id: stop_timer
+      shell: bash
+      run: |
+        export END_TIME="$(printf '%(%s)T\n' -1)"
+        export TIME_ELAPSED="$(($END_TIME-$START_TIME))"
+        export DURATION="$(printf '%dm:%ds\n' $((TIME_ELAPSED%3600/60)) $((TIME_ELAPSED%60)))"
+
+        echo "END_TIME="$END_TIME"" >> $GITHUB_ENV
+        echo "DURATION="$DURATION"" >> $GITHUB_ENV
+        echo "JOB_STATUS=${{ inputs.job_status }}" >> $GITHUB_ENV
+
+    - name: Set Job Icon From Status
+      id: set_job_icon
+      shell: bash
+      run: |
+        export JOB_STATUS="${{ job.status }}"
+        export JOB_ICON="${{ inputs.ICON_UNKNOWN }}"
+
+        if test "$JOB_STATUS" == 'success' ; then
+          export JOB_ICON="${{ inputs.ICON_SUCCESS }}"
+        elif test "$JOB_STATUS" == 'failure' ; then
+          export JOB_ICON="${{ inputs.ICON_FAIL }}"
+        elif test "$JOB_STATUS" == 'cancelled' ; then
+          export JOB_ICON="${{ inputs.ICON_CANCEL }}"
+        else
+          echo "Warning: Unknown job JOB_STATUS: $JOB_STATUS"
+          export JOB_ICON="${{ inputs.ICON_UNKNOWN }}"
+        fi
+
+        echo "JOB_STATUS="$JOB_STATUS"" >> $GITHUB_ENV
+        echo "JOB_ICON="$JOB_ICON"" >> $GITHUB_ENV
+
+    - name: Write Step Outcomes to Body
+      id: map_step_outcomes
+      shell: bash
+      env:
+        STEPS_CONTEXT: ${{ inputs.parent_steps }}
+        NOTIFY_FILE: ${{ inputs.notification_body_file }}
+      run: |
+        while IFS=, read -r step outcome
+        do
+          if test "$outcome" == 'failure' ; then
+            step_icon="${{ inputs.ICON_FAIL }}"
+          elif test "$outcome" == 'success' ; then
+            step_icon="${{ inputs.UNI_SUCCESS }}"
+          elif test "$outcome" == 'cancelled' ; then
+            step_icon="${{ inputs.UNI_CANCEL }}"
+          elif test "$outcome" == 'skipped' ; then
+            step_icon="${{ inputs.UNI_SKIP }}"
+          else
+            echo "Warning, Unknown step outcome '$outcome'"
+            step_icon="${{ inputs.ICON_UNKNOWN }}"
+          fi
+
+          echo "&emsp;${step_icon}&emsp;${step}" >> "$NOTIFY_FILE"
+        done < <(echo "$STEPS_CONTEXT" | jq -r 'keys[] as $k | "\($k),\(.[$k] | .outcome)"' -)
+
+        echo "" >> "$NOTIFY_FILE"
+        echo "&emsp;&#9719;&emsp; _${DURATION}_" >> "$NOTIFY_FILE"
+        echo "" >> "$NOTIFY_FILE"
+
+    - name: Send Notification
+      id: send_notification
+      shell: bash
+      env:
+        NOTIFY_FILE: ${{ inputs.notification_body_file }}
+      run: |
+        ./.ci/notify.sh "$NOTIFY_FILE"
+

--- a/.github/actions/notifier-start/action.yml
+++ b/.github/actions/notifier-start/action.yml
@@ -1,0 +1,43 @@
+# The Book on Composite Actions
+# https://github.com/actions/runner/issues/646
+
+name: 'Notifier Start'
+description: 'Setup the workflow environment for timing and notifying'
+runs:
+  using: "composite"
+  steps:
+    - name: Setup environment variables
+      id: env_setup
+      shell: bash
+      env:
+        COMMIT_MSG: ${{ github.event.head_commit.message }}
+      run: |
+        echo "BRANCH_NAME="${GITHUB_REF#refs/heads/}"" >> $GITHUB_ENV
+        echo "SHORT_COMMIT="${GITHUB_SHA:0:8}"" >> $GITHUB_ENV
+        echo "COMMIT_MSG_TRUNCATED="${COMMIT_MSG:0:50}"" >> $GITHUB_ENV
+        echo "START_TIME="$(printf '%(%s)T\n' -1)"" >> $GITHUB_ENV
+    - name: Setup Notification Preamble
+      id: setup_notification_preamble
+      shell: bash
+      run: |
+        echo -n "${{format('\
+        **[\`{2}:{3}\`]({0}/{1}/actions/runs/{3}?check_suite_focus=true)**\
+        &emsp;on [{1}]({0}/{1})&emsp;([all actions]({0}/{1}/actions))&emsp;
+
+        &nbsp;&nbsp;&nbsp;&emsp;&emsp;[\`{4}\`]({0}/{1}/tree/{4}):[\`{5}\`]({0}/{1}/commit/{6})\
+        &emsp;([compare]({8}))&emsp;{7}push&emsp;by [{9}]({0}/{9})
+
+        &nbsp;&nbsp;&nbsp;&emsp;&emsp;\`{10}...\`
+        ',
+          'https://www.github.com',
+          github.repository,
+          github.job,
+          github.run_id,
+          env.BRANCH_NAME,
+          env.SHORT_COMMIT,
+          github.sha,
+          github.event.forced && 'force ' || '',
+          github.event.compare,
+          github.actor,
+          env.COMMIT_MSG_TRUNCATED
+        ) }}" > preamble.txt

--- a/.github/workflows/build_and_deploy_preview.yml
+++ b/.github/workflows/build_and_deploy_preview.yml
@@ -12,52 +12,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup environment variables
-        id: env_setup
-        env:
-          COMMIT_MSG: ${{ github.event.head_commit.message }}
-        run: |
-          echo "BRANCH_NAME="${GITHUB_REF#refs/heads/}"" >> $GITHUB_ENV
-          echo "SHORT_COMMIT="${GITHUB_SHA:0:8}"" >> $GITHUB_ENV
-          echo "COMMIT_MSG_TRUNCATED="${COMMIT_MSG:0:50}"" >> $GITHUB_ENV
-          echo "START_TIME="$(printf '%(%s)T\n' -1)"" >> $GITHUB_ENV
-      - name: Print env
-        run: |
-          echo "${{ env.BRANCH_NAME }}" && echo "${{ env.SHORT_COMMIT }}"
 
+      # Start a timer and set the preamble for the notification
+      - uses: ./.github/actions/notifier-start
+        if: always() && !env.ACT
+
+      # Use Node 15 for now, but it's not LTS
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
           node-version: 15.x
+
+      # Setup
       - name: Setup ACT debugging container
         if: ${{ env.ACT }}
         run: ./.ci/debug/setup_debugging.sh
-      - name: Setup Notification Preamble
-        if: always() && !env.ACT
-        run: |
-          echo -n "${{format('\
-          **[\`{2}:{3}\`]({0}/{1}/actions/runs/{3}?check_suite_focus=true)**\
-          &emsp;on [{1}]({0}/{1})&emsp;([all actions]({0}/{1}/actions))&emsp;
-
-          &nbsp;&nbsp;&nbsp;&emsp;&emsp;[\`{4}\`]({0}/{1}/tree/{4}):[\`{5}\`]({0}/{1}/commit/{6})\
-          &emsp;([compare]({8}))&emsp;{7}push&emsp;by [{9}]({0}/{9})
-
-          &nbsp;&nbsp;&nbsp;&emsp;&emsp;\`{10}...\`
-          ',
-            'https://www.github.com',
-            github.repository,
-            github.job,
-            github.run_id,
-            env.BRANCH_NAME,
-            env.SHORT_COMMIT,
-            github.sha,
-            github.event.forced && 'force ' || '',
-            github.event.compare,
-            github.actor,
-            env.COMMIT_MSG_TRUNCATED
-          ) }}" > preamble.txt
-
-      # Setup
       - name: Setup Tooling
         id: setup
         run: ./setup.sh
@@ -94,70 +63,9 @@ jobs:
         env:
           DOCSEARCH_PUBLIC_CLIENT_API_KEY: ${{ secrets.DOCSEARCH_PUBLIC_CLIENT_API_KEY }}
 
-      # Notifications
-      - name: Calculate Time
-        if: always()
-        run: |
-          export END_TIME="$(printf '%(%s)T\n' -1)"
-          export TIME_ELAPSED="$(($END_TIME-$START_TIME))"
-          export DURATION="$(printf '%dm:%ds\n' $((TIME_ELAPSED%3600/60)) $((TIME_ELAPSED%60)))"
-          echo "END_TIME="$END_TIME"" >> $GITHUB_ENV
-          echo "DURATION="$DURATION"" >> $GITHUB_ENV
-      - name: Send Notification
-        if: always()
-        env:
-          ICON_SUCCESS: ':white_check_mark:'
-          ICON_FAIL: ':skull_and_crossbones:'
-          ICON_CANCEL: ':heavy_multiplication_x:'
-          ICON_UNKNOWN: ':grey_question:'
-
-          UNI_SUCCESS: '&#10003;'
-          UNI_CANCEL: '&#88;'
-          UNI_SKIP: '&#8213;'
-          UNI_UNKNOWN: '&#63;'
-        run: |
-          echo -n "${{
-            format('
-          &emsp;{0}&emsp;Setup
-          &emsp;{1}&emsp;Install
-          &emsp;{2}&emsp;Typecheck
-          &emsp;{3}&emsp;Build
-          &emsp;&#9719;&emsp; _{4}_
-          ',
-          steps.setup.outcome == 'success' && env.UNI_SUCCESS
-            || ( steps.setup.outcome == 'failure' && env.ICON_FAIL
-              || (steps.setup.outcome == 'cancelled' && env.UNI_CANCEL
-                || env.UNI_SKIP || env.UNI_UNKNOWN)),
-
-          steps.install.outcome == 'success' && env.UNI_SUCCESS
-            || ( steps.install.outcome == 'failure' && env.ICON_FAIL
-              || (steps.install.outcome == 'cancelled' && env.UNI_CANCEL
-                || env.UNI_SKIP || env.UNI_UNKNOWN)),
-
-          steps.typecheck.outcome == 'success' && env.UNI_SUCCESS
-            || ( steps.typecheck.outcome == 'failure' && env.ICON_FAIL
-              || (steps.typecheck.outcome == 'cancelled' && env.UNI_CANCEL
-                || env.UNI_SKIP || env.UNI_UNKNOWN)),
-
-          steps.build.outcome == 'success' && env.UNI_SUCCESS
-            || ( steps.build.outcome == 'failure' && env.ICON_FAIL
-              || (steps.build.outcome == 'cancelled' && env.UNI_CANCEL
-                || env.UNI_SKIP || env.UNI_UNKNOWN)),
-
-          env.DURATION
-          ) }}" >> notify.txt \
-            && JOB_ICON="${{ job.status == 'success' && env.ICON_SUCCESS
-                      || ( job.status == 'failure ' && env.ICON_FAIL
-                      || job.status == 'cancelled' && env.ICON_CANCEL
-                      || env.ICON_UNKNOWN ) }}" \
-              .ci/notify.sh notify.txt
-
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
-        run: echo "$GITHUB_CONTEXT"
-
-      - name: Dump Job context
-        env:
-          JOB_CONTEXT: ${{ toJSON(job) }}
-        run: echo "$JOB_CONTEXT"
+      # Stop the timer, format the message, and send the notification
+      - uses: ./.github/actions/notifier-complete
+        if: always() && !env.ACT
+        with:
+          job_status: ${{ job.status }}
+          parent_steps: "${{ toJSON(steps) }}"

--- a/.github/workflows/build_and_deploy_preview.yml
+++ b/.github/workflows/build_and_deploy_preview.yml
@@ -7,8 +7,24 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
+    env:
+      NOTIFY_WEBHOOK: ${{ secrets.NOTIFY_WEBHOOK }}
+
     steps:
       - uses: actions/checkout@v2
+      - name: Setup environment variables
+        id: env_setup
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          echo "BRANCH_NAME="${GITHUB_REF#refs/heads/}"" >> $GITHUB_ENV
+          echo "SHORT_COMMIT="${GITHUB_SHA:0:8}"" >> $GITHUB_ENV
+          echo "COMMIT_MSG_TRUNCATED="${COMMIT_MSG:0:50}"" >> $GITHUB_ENV
+          echo "START_TIME="$(printf '%(%s)T\n' -1)"" >> $GITHUB_ENV
+      - name: Print env
+        run: |
+          echo "${{ env.BRANCH_NAME }}" && echo "${{ env.SHORT_COMMIT }}"
+
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
@@ -16,72 +32,132 @@ jobs:
       - name: Setup ACT debugging container
         if: ${{ env.ACT }}
         run: ./.ci/debug/setup_debugging.sh
-      - run: ./setup.sh
+      - name: Setup Notification Preamble
+        if: always() && !env.ACT
+        run: |
+          echo -n "${{format('\
+          **[\`{2}:{3}\`]({0}/{1}/actions/runs/{3}?check_suite_focus=true)**\
+          &emsp;on [{1}]({0}/{1})&emsp;([all actions]({0}/{1}/actions))&emsp;
+
+          &nbsp;&nbsp;&nbsp;&emsp;&emsp;[\`{4}\`]({0}/{1}/tree/{4}):[\`{5}\`]({0}/{1}/commit/{6})\
+          &emsp;([compare]({8}))&emsp;{7}push&emsp;by [{9}]({0}/{9})
+
+          &nbsp;&nbsp;&nbsp;&emsp;&emsp;\`{10}...\`
+          ',
+            'https://www.github.com',
+            github.repository,
+            github.job,
+            github.run_id,
+            env.BRANCH_NAME,
+            env.SHORT_COMMIT,
+            github.sha,
+            github.event.forced && 'force ' || '',
+            github.event.compare,
+            github.actor,
+            env.COMMIT_MSG_TRUNCATED
+          ) }}" > preamble.txt
+
+      # Setup
+      - name: Setup Tooling
+        id: setup
+        run: ./setup.sh
+
+      # Install
       - uses: actions/cache@v1
         with:
           path: /home/runner/yarn-cache
           key: yarncache
-      - run: ./.ci/install.sh
+      - name: Install Packages
+        id: install
+        run: ./.ci/install.sh
         env:
           YARN_CACHE_FOLDER: /home/runner/yarn-cache
-
           # For debugging only, but must be defined here or `act` ignores it
           BREAK_INTERACTIVE_BEFORE_INSTALL: ${{ secrets.BREAK_INTERACTIVE_BEFORE_INSTALL }}
-      - run: ./.ci/build.sh
+
+      # Typecheck
+      - uses: actions/cache@v1
+        with:
+          path: ${github.workspace}
+          key: typecache
+      - name: Typecheck
+        id: typecheck
+        run: .ci/typecheck.sh
+
+      # Build
+      - name: Build Static Website
+        id: build
+
+        # Temporary: Builds take forever. Make them opt in with a pragma.
+        if: "contains(github.event.head_commit.message, '[build]')"
+        run: ./.ci/build.sh
         env:
           DOCSEARCH_PUBLIC_CLIENT_API_KEY: ${{ secrets.DOCSEARCH_PUBLIC_CLIENT_API_KEY }}
-      # - run: ./.ci/deploy_preview.sh
-      #   env:
-      #     NOW_TOKEN: ${{ secrets.NOW_TOKEN }}
-      #     NOW_PROJECT_ID: ${{ secrets.NOW_PROJECT_ID }}
-      #     NOW_ORG_ID: ${{ secrets.NOW_ORG_ID }}
-      - uses: actions/upload-artifact@v2
-        with:
-          name: website
-          path: ./docs/out
-      # - run: ./.ci/get_preview_url.sh preview_url.txt
-      # - run: cat preview_url.txt
-      # - uses: actions/upload-artifact@v2
-      #   with:
-      #     name: preview_url.txt
-      #     path: preview_url.txt
 
-  release_master:
-    runs-on: ubuntu-latest
-    needs: build_and_deploy_preview
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: website
-          path: website
-      - name: List artifact
-        run: ls -R website
-      - name: Remove preview artifacts (robots.txt)
-        run: rm website/robots.txt || true
-      - name: Create release tarball
-        run: tar -cz -f /home/runner/release.tar.gz -C /home/runner/work/splitgraph.com/splitgraph.com/website .
-      - name: Get current date
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H%M')"
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+      # Notifications
+      - name: Calculate Time
+        if: always()
+        run: |
+          export END_TIME="$(printf '%(%s)T\n' -1)"
+          export TIME_ELAPSED="$(($END_TIME-$START_TIME))"
+          export DURATION="$(printf '%dm:%ds\n' $((TIME_ELAPSED%3600/60)) $((TIME_ELAPSED%60)))"
+          echo "END_TIME="$END_TIME"" >> $GITHUB_ENV
+          echo "DURATION="$DURATION"" >> $GITHUB_ENV
+      - name: Send Notification
+        if: always()
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{steps.date.outputs.date}}.${{ github.run_id }}
-          release_name: Release ${{steps.date.outputs.date}}.${{ github.run_id }}
-          draft: false
-          prerelease: false
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
+          ICON_SUCCESS: ':white_check_mark:'
+          ICON_FAIL: ':skull_and_crossbones:'
+          ICON_CANCEL: ':heavy_multiplication_x:'
+          ICON_UNKNOWN: ':grey_question:'
+
+          UNI_SUCCESS: '&#10003;'
+          UNI_CANCEL: '&#88;'
+          UNI_SKIP: '&#8213;'
+          UNI_UNKNOWN: '&#63;'
+        run: |
+          echo -n "${{
+            format('
+          &emsp;{0}&emsp;Setup
+          &emsp;{1}&emsp;Install
+          &emsp;{2}&emsp;Typecheck
+          &emsp;{3}&emsp;Build
+          &emsp;&#9719;&emsp; _{4}_
+          ',
+          steps.setup.outcome == 'success' && env.UNI_SUCCESS
+            || ( steps.setup.outcome == 'failure' && env.ICON_FAIL
+              || (steps.setup.outcome == 'cancelled' && env.UNI_CANCEL
+                || env.UNI_SKIP || env.UNI_UNKNOWN)),
+
+          steps.install.outcome == 'success' && env.UNI_SUCCESS
+            || ( steps.install.outcome == 'failure' && env.ICON_FAIL
+              || (steps.install.outcome == 'cancelled' && env.UNI_CANCEL
+                || env.UNI_SKIP || env.UNI_UNKNOWN)),
+
+          steps.typecheck.outcome == 'success' && env.UNI_SUCCESS
+            || ( steps.typecheck.outcome == 'failure' && env.ICON_FAIL
+              || (steps.typecheck.outcome == 'cancelled' && env.UNI_CANCEL
+                || env.UNI_SKIP || env.UNI_UNKNOWN)),
+
+          steps.build.outcome == 'success' && env.UNI_SUCCESS
+            || ( steps.build.outcome == 'failure' && env.ICON_FAIL
+              || (steps.build.outcome == 'cancelled' && env.UNI_CANCEL
+                || env.UNI_SKIP || env.UNI_UNKNOWN)),
+
+          env.DURATION
+          ) }}" >> notify.txt \
+            && JOB_ICON="${{ job.status == 'success' && env.ICON_SUCCESS
+                      || ( job.status == 'failure ' && env.ICON_FAIL
+                      || job.status == 'cancelled' && env.ICON_CANCEL
+                      || env.ICON_UNKNOWN ) }}" \
+              .ci/notify.sh notify.txt
+
+      - name: Dump GitHub context
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: /home/runner/release.tar.gz
-          asset_name: website.tar.gz
-          asset_content_type: application/gzip
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Dump Job context
+        env:
+          JOB_CONTEXT: ${{ toJSON(job) }}
+        run: echo "$JOB_CONTEXT"

--- a/README.md
+++ b/README.md
@@ -242,16 +242,22 @@ const DemoStyled = styled.div`
 # Debugging CI
 
 ```bash
-# Start `act`
+
+# To run it all the way through, just run this command:
 .ci/debug/run_act.sh
 
-# "Break" before running bulk of install step (see `install.sh`)
+# Note: No apparent way to run act as a daemon; it only runs in the foreground
+# So, to drop into a debugger, open two terminals: one to run, and one to attach
+
+# In (1), Run and "break" before pre-install. See `install.sh` (it's a sleep loop)
 .ci/debug/run_act_break_before_install.sh
 
-# The "break" is just an infinite loop of `sleep 10`
-# To get an interactive shell, need to `docker exec` into that container
+
+
+# In (2), Attach an interactive shell to the container in (1), with `docker exec`:
+# (When (1) hits the breakpoint, it will print this command before sleeping)
 docker exec -it $(docker ps -q --filter name=act-*) /bin/bash
 
-# If you need to kill the container
+# If you need to kill the container, ctrl+c isn't enough
 docker kill $(docker ps -q --filter name=act-*)
 ```

--- a/tdesign/src/themes/design.ts
+++ b/tdesign/src/themes/design.ts
@@ -1,4 +1,14 @@
-export const theme = {
+import { Theme } from "@emotion/react";
+
+interface SplitgraphTheme extends Theme {
+  grays: any;
+  primary: any;
+  navbar: any;
+  footer: any;
+  surfaces: any;
+}
+
+export const theme: SplitgraphTheme = {
   // Grays //////////////////
   grays: {
     light: {


### PR DESCRIPTION
Simplify the build

- Separate typecheck and build steps
- Make long build step opt-in via commit message pragma `[build]`
- Remove the deployment actions for now since our bundle is too big for Vercel anyway..

Create actions for wrapping a workflow with timing / notification functionality:

- Set a timer for the whole job
- Parse the status of each step with an ID
- Format the notification message as friendly markdown with all the requisite metadata
- Send a Mattermost WebHook to the configured secret `$NOTIFY_WEBHOOK`
- Use composite actions to simplify the code

Any workflow (in any repository) can get the same by wrapping itself with the same two actions:

- https://github.com/splitgraph/splitgraph.com/blob/dev/ts-fixes/.github/workflows/build_and_deploy_preview.yml#L16-L18
- https://github.com/splitgraph/splitgraph.com/blob/dev/ts-fixes/.github/workflows/build_and_deploy_preview.yml#L67-L71