### PR TITLE
Update readme, fix CSS regression, pin yarn

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -17,11 +17,9 @@ if test ! -d dist ; then
     exit 1
 fi
 
-echo "Temporary quick build" && popd && exit 0
-
-# yarn build \
-#     && cp "$SPLITGRAPH_DIR"/docs/proxyDirectories.txt "$SPLITGRAPH_DIR"/docs/out/proxyDirectories.txt \
-#     && echo "Build successful" \
-#     && exit 0
+yarn build \
+    && cp "$SPLITGRAPH_DIR"/docs/proxyDirectories.txt "$SPLITGRAPH_DIR"/docs/out/proxyDirectories.txt \
+    && echo "Build successful" \
+    && exit 0
 
 exit 1

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -28,6 +28,7 @@ fi
 # We need to set the special lockfile name here, because if we use yarn.lock,
 # then when running in the parent monorepo, yarn will think its in its own root
 export WORKSPACE_LOCKFILE=yarn-public-workspace.lock
+export DEBUG=1
 pushd "$SPLITGRAPH_DIR" \
     && ./setup.sh \
     && yarn install --immutable \

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ libmdx
 # !.yarn/plugins/*
 
 dist
+
+# During development it can be useful to serve a rootCA.pem 
+# from `docs/public/static` for easy download on a mobile device
+*.pem

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,10 +1,13 @@
-
 nodeLinker: node-modules
 
 plugins:
-  - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.js
-    spec: "@yarnpkg/plugin-workspace-tools"
-  - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.js
-    spec: "@yarnpkg/plugin-interactive-tools"
   - path: .yarn/plugins/@yarnpkg/plugin-workspace-lockfile.js
     spec: "https://raw.githubusercontent.com/milesforks/yarn-plugin-workspace-lockfile/main/packages/plugin/bundles/%40yarnpkg/plugin-workspace-lockfile.js"
+  - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.js
+    spec: "https://raw.githubusercontent.com/yarnpkg/berry/%40yarnpkg/plugin-interactive-tools/2.2.0/packages/plugin-interactive-tools/bin/%40yarnpkg/plugin-interactive-tools.js"
+  - path: .yarn/plugins/@yarnpkg/plugin-constraints.js
+    spec: "https://raw.githubusercontent.com/yarnpkg/berry/%40yarnpkg/plugin-constraints/2.2.0/packages/plugin-constraints/bin/%40yarnpkg/plugin-constraints.js"
+  - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.js
+    spec: "https://raw.githubusercontent.com/yarnpkg/berry/%40yarnpkg/plugin-workspace-tools/2.2.0/packages/plugin-workspace-tools/bin/%40yarnpkg/plugin-workspace-tools.js"
+
+yarnPath: .yarn/releases/yarn-berry.js

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 As of 7/8/21, these instructions should get you running locally. It's still a WIP.
 
 **NOTE: Make sure you check out `canary` of this repository! The default `master` branch is not up to date.**
+
+<details><summary>Installation and Setup
+</summary><p>
+
 ## Cloning
 
 You can get started by copying this command and pasting it into your Terminal:
@@ -12,6 +16,7 @@ git clone git@github.com:splitgraph/splitgraph.com.git \
   && cd splitgraph.com \
   && git checkout --track origin/canary
 ```
+
 ## Installation
 
 Assumptions:
@@ -58,6 +63,11 @@ Troubleshooting:
   - Any version lower than `15.x` is unlikely to work
 - Directory permission errors
   - Make sure you own the current directory and any existing `node_modules` subdirectory
+
+</p></details>
+
+<details><summary>Developing
+</summary><p>
 
 ## Note!
 
@@ -113,10 +123,11 @@ To get started, you can try editing the demo `lp` page linked above.
 
 For the most part, this is a standard Next.js app in `docs`
 
+</p></details>
 
-# Docs
-
-## Code Layout: What are the folders for?
+<details><summary>Code Layout: What are the folders for?
+</summary>
+<p>
 
 The `splitgraph.com` repository is a TypeScript mono-repo with multiple
 workspaces. Most importantly, the [`docs`](./docs) workspace is a Next.js app, and
@@ -132,19 +143,18 @@ yarn installation.
 
 - [splitgraph.com](./docs)
   - The root workspace. You can run most commands from here, which it mostly
-  forwards to the `docs` workspace anyway.
+    forwards to the `docs` workspace anyway.
 - [docs](./docs) (Import from `@splitgraph/docs`)
   - The Next.js app that is the primary entrypoint of the repository
 - [tdesign](./tdesign) (Import from `@splitgraph/tdesign`)
   - The design kit / component library / theme / etc. Very much a WIP.
-  - It's called "`tdesign`" as in "typescript design`, because originally
-  we had JS files in `design`, and we are still migrating that.
+  - It's called "`tdesign`" as in "typescript design`, because originally we had JS files in `design`, and we are still migrating that.
 
 ### Less important workspaces
 
 - [design](./design) (Import from `@splitgraph/design`)
   - The deprecated design kit, which might still be used in a few places.
-  You can mostly ignore this.
+    You can mostly ignore this.
 - [lib](./lib) (Import from `@splitgraph/lib`)
   - Utilities and library functions
 - [content-scripts](./content-scripts) (not for importing)
@@ -166,6 +176,12 @@ it in the design library at `@splitgraph/tdesign`.
 
 When creating components, try to follow the existing style (we'll eventually
 document this / add linter / scaffolding scripts).)
+
+</p>
+</details>
+
+<details><summary>Theming
+</summary><p>
 
 ## Whats the story with theming?
 
@@ -194,7 +210,6 @@ These are the three themes you could import:
 These examples are available in
 [docs/components/DemoComponents](./docs/components/DemoComponents).
 
-
 - `sx` + `className`:
   React's built-in `className` prop can be a useful (and styling library agnostic) way to target child components.
   You can define some styles in a parent and pass them into the children like so:
@@ -209,7 +224,7 @@ const styles = {
     <p>Hello</p>
   </Child>
 </Parent>
-````
+```
 
 - `css` prop
   Emotion gives us a css prop that accepts vanilla CSS.
@@ -239,7 +254,11 @@ const DemoStyled = styled.div`
   }};
 `;
 ```
-# Debugging CI
+
+</p></details>
+
+<details><summary>Debugging CI
+</summary><p>
 
 ```bash
 
@@ -252,8 +271,6 @@ const DemoStyled = styled.div`
 # In (1), Run and "break" before pre-install. See `install.sh` (it's a sleep loop)
 .ci/debug/run_act_break_before_install.sh
 
-
-
 # In (2), Attach an interactive shell to the container in (1), with `docker exec`:
 # (When (1) hits the breakpoint, it will print this command before sleeping)
 docker exec -it $(docker ps -q --filter name=act-*) /bin/bash
@@ -261,3 +278,99 @@ docker exec -it $(docker ps -q --filter name=act-*) /bin/bash
 # If you need to kill the container, ctrl+c isn't enough
 docker kill $(docker ps -q --filter name=act-*)
 ```
+
+</p></details>
+
+<details><summary>Installing on a fresh system with `nvm` (rough notes)
+</summary>
+<p>
+
+This was my experience cloning on a Mac recently. The instructions above contain
+the important steps, but this section includes more details and troubleshooting
+from a recent installation on a Mac. (e.g. note it doesn't include the tsconfig
+details, but that's still necessary). This process will be smoothed out
+eventually.
+
+## Install nvm
+
+Install nvm: https://github.com/nvm-sh/nvm#installing-and-updating
+
+Make sure correct lines are in `~/.bash_profile`, and if you add them,
+make sure to `source ~/.bash_profile` afterward.
+
+(taken from the above link)
+
+```bash
+export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
+```
+
+## After cloning, create an environment
+
+```bash
+# example (note that v15 is not LTS)
+ nvm install 15.12.0
+```
+
+## Install yarn
+
+```bash
+npm install -g yarn
+```
+
+## Try to setup
+
+```bash
+./setup.sh
+```
+
+Errors like this?
+
+```bash
+❯ yarn --version
+node:internal/modules/cjs/loader:927
+  throw err;
+  ^
+
+Error: Cannot find module '/private/tmp/splitgraph.com/.yarn/releases/yarn-berry.cjs'
+    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:924:15)
+    at Function.Module._load (node:internal/modules/cjs/loader:769:27)
+    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:76:12)
+    at node:internal/main/run_main_module:17:47 {
+  code: 'MODULE_NOT_FOUND',
+  requireStack: []
+}
+```
+
+Clean up
+
+```bash
+find .yarn -type f -delete
+rm .yarnrc
+./setup.sh
+
+```
+
+Get error again?
+
+Check `.yarnrc.yml` to make sure it's point to yarn release with the same file extension as the relase on your system. If not, edit the file `vi .yarnrc.yml` to change the extension.
+
+```bash
+cat .yarnrc.yml
+```
+
+Mismatch:
+
+```bash
+
+❯ cat .yarnrc.yml
+yarnPath: ".yarn/releases/yarn-berry.cjs" # <--- should be .js
+
+/tmp/splitgraph.com ⋄ canary-header*
+❯ ls .yarn/releases/
+yarn-berry.js   # <--- the file is .js
+
+```
+
+</p>
+</details>

--- a/tdesign/src/Layout/BaseLayout/BaseLayout.tsx
+++ b/tdesign/src/Layout/BaseLayout/BaseLayout.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { Box, useMediaQuery } from "@material-ui/core";
 import { useTheme } from "@material-ui/core/styles";
+import { SxProps } from "@material-ui/system";
+import type { Theme } from "@material-ui/core/styles/createMuiTheme";
 
 import {
   Header,
@@ -31,13 +33,15 @@ const BaseLayout = ({
   showHeader = true,
   logoText,
 }: BaseLayoutProps) => {
-  const containerStyle = {
+  const containerStyle: SxProps<Theme> = {
     // maxWidth: '100vw',
     // minWidth: "-webkit-fit-content",
     // width: "100vw",
-    ".logo-link": {
-      variant: "links.unstyled",
-    },
+
+    // TODO: Deprecated variant syntax only works with legacyTheme
+    // ".logo-link": {
+    //   variant: "links.unstyled",
+    // },
     ".button-link": {
       // from theme-ui's links.button
       backgroundColor: "primary.main",
@@ -61,10 +65,15 @@ const BaseLayout = ({
       },
       display: "inline-table",
     },
-    ".button-link-secondary": {
-      variant: "links.buttonSecondary",
-      display: "inline-table",
-    },
+
+    // TODO: Deprecated variant syntax only works with legacyTheme
+    // ".logo-link": {
+    //   variant: "links.unstyled",
+    // },
+    // ".button-link-secondary": {
+    //   variant: "links.buttonSecondary",
+    //   display: "inline-table",
+    // },
     // weird hack needs two class names to refer to same element...
     ".logo-link-flex": {
       display: "flex",

--- a/tdesign/src/Layout/BaseLayout/BaseLayout.tsx
+++ b/tdesign/src/Layout/BaseLayout/BaseLayout.tsx
@@ -34,7 +34,7 @@ const BaseLayout = ({
   const containerStyle = {
     // maxWidth: '100vw',
     // minWidth: "-webkit-fit-content",
-    width: "100vw",
+    // width: "100vw",
     ".logo-link": {
       variant: "links.unstyled",
     },

--- a/yarn-public-workspace.lock
+++ b/yarn-public-workspace.lock
@@ -9931,11 +9931,11 @@ typescript@4.2.4:
 
 "typescript@patch:typescript@4.2.4#builtin<compat/typescript>":
   version: 4.2.4
-  resolution: "typescript@patch:typescript@npm%3A4.2.4#builtin<compat/typescript>::version=4.2.4&hash=ddfc1b"
+  resolution: "typescript@patch:typescript@npm%3A4.2.4#builtin<compat/typescript>::version=4.2.4&hash=a45b0e"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 64658fdf27872904641dcaacf925e6b5a52fb4aa4881a5a726fc78a11b76748423ce9e996dac42313729321061c4dd38a06108014f8d07b222dcff2687037186
+  checksum: 3be44317593182e8ce494c114e7ad9b0bb2553a22f3085cc6da4f0a36912c20850daa9be4c898af2ab6fc8b12f430c1c9e46ac715721867cd38643f2350d3ef9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Update readme with rough notes from installing via nvm in fresh repo (note this was before last night's setup.sh changes – might be slightly different now)
- Make small CSS change... that's all this was supposed to be but...
- Fix Yarn bugs caused by Yarn recently upgrading to `3.0.0` and deprecating the patch fix we had at `2.4.2`. Long story short, we're pinned to yarn `2.4.1`, and also pinned our plugins. 

Make sure you run `./setup.sh` after pulling/rebasing.

If you ever do `yarn --version` and it says anything other than `2.4.1`, you need to run `./setup.sh` again.

@onpaws as discussed, rebase on this after merge to canary