### PR TITLE
Remove grey background for pill button from muiTheme

### DIFF
--- a/tdesign/src/themes/muiTheme.ts
+++ b/tdesign/src/themes/muiTheme.ts
@@ -319,7 +319,6 @@ export const muiTheme = ({
               // Reset on touch devices, it doesn't add specificity
               "@media (hover: none)": {
                 boxShadow: baseTheme.shadows[2],
-                backgroundColor: baseTheme.palette.grey[300],
               },
             },
           },


### PR DESCRIPTION
- Caused pill load more button to be grey on mobile
- CU-1crtppy