### PR TITLE
Update readme, exclude storybook output files from typechecking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 As of 7/8/21, these instructions should get you running locally. It's still a WIP.
 
-**NOTE: Make sure you check out `canary` of this repository! The default `master` branch is not up to date.**
-
 <details><summary>Installation and Setup
 </summary><p>
 
@@ -13,8 +11,7 @@ You can get started by copying this command and pasting it into your Terminal:
 
 ```bash
 git clone git@github.com:splitgraph/splitgraph.com.git \
-  && cd splitgraph.com \
-  && git checkout --track origin/canary
+  && cd splitgraph.com
 ```
 
 ## Installation

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -11,5 +11,5 @@
     { "path": "../templaters" }
   ],
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.jsx", "**/*.js"],
-  "exclude": ["node_modules", "pages/_content", ".next"]
+  "exclude": ["node_modules", "pages/_content", ".next", "out", "out-storybook"]
 }


### PR DESCRIPTION
- Update readme to remove note about `canary` (we're on `master` now)
- Exclude `storybook-out` from typechecking in `docs/tsconfig.json`
- This wouldn't have been noticeable locally unless you've
  built storybook at least once before, and then a typecheck
  tried to include storybook built files for some reason