### PR TITLE
Add some constants and magic numbers to the theme

### DIFF
--- a/tdesign/src/Layout/Header/Header.tsx
+++ b/tdesign/src/Layout/Header/Header.tsx
@@ -30,11 +30,7 @@ const Header = ({ children }: HeaderProps) => {
       className="header--container"
       sx={
         {
-          display: "grid",
-          gridColumnGap: "0px",
-          gridTemplateColumns:
-            "min-content repeat(1, minmax(25vw, 1fr)) min-content",
-          gridAutoFlow: "column",
+          ...theme.grids.threeCol,
           background: ({ palette }) => palette.navbar.main,
 
           // !! HACK

--- a/tdesign/src/Layout/PaddedSingleCol/PaddedSingleCol.tsx
+++ b/tdesign/src/Layout/PaddedSingleCol/PaddedSingleCol.tsx
@@ -1,0 +1,51 @@
+import { Box } from "@material-ui/core";
+import { useTheme } from "@material-ui/core/styles";
+import { SxProps } from "@material-ui/system";
+import { Theme } from "@material-ui/core/styles/createMuiTheme";
+
+interface IPaddedSingleColProps {
+  className?: string;
+  innerClassName?: string;
+  children: React.ReactNode;
+  extraStyle?: SxProps<Theme>;
+
+  /** Not literally padding-left. Will be set as minWidth of left spacer. */
+  leftPadding?: string | number;
+  /** Not literally padding-right. Will be set as minWidth of left spacer. */
+  rightPadding?: string | number;
+}
+
+const PaddedSingleCol = ({
+  children,
+  className,
+  innerClassName,
+  leftPadding,
+  rightPadding,
+  extraStyle = {},
+}: IPaddedSingleColProps) => {
+  const theme = useTheme();
+
+  const outerClass = `padded-single-col-grid ${className ?? ""}`.trim();
+  const innerClass = `center-padded-content ${innerClassName ?? ""}`.trim();
+
+  const outerContainerStyle: SxProps<Theme> = {
+    ...theme.grids.threeCol,
+    ".left-spacer": {
+      minWidth: leftPadding ?? theme.constants.leftMarginInsideLogo,
+    },
+    ".right-spacer": {
+      minWidth: rightPadding ?? theme.constants.rightMarginInsideNavProfileMenu,
+    },
+    ...extraStyle,
+  };
+
+  return (
+    <Box className={outerClass} sx={outerContainerStyle}>
+      <div className="left-spacer">&nbsp;</div>
+      <div className={innerClass}>{children}</div>
+      <div className="right-spacer">&nbsp;</div>
+    </Box>
+  );
+};
+
+export default PaddedSingleCol;

--- a/tdesign/src/Layout/PaddedSingleCol/index.tsx
+++ b/tdesign/src/Layout/PaddedSingleCol/index.tsx
@@ -1,0 +1,2 @@
+import PaddedSingleCol from "./PaddedSingleCol";
+export { PaddedSingleCol };

--- a/tdesign/src/Layout/index.tsx
+++ b/tdesign/src/Layout/index.tsx
@@ -25,3 +25,5 @@ export { ContentHeader } from "./ContentHeader";
 export { Footer } from "./Footer";
 export { Logo } from "./Logo";
 export type { ILogoProps } from "./Logo";
+
+export { PaddedSingleCol } from "./PaddedSingleCol";

--- a/tdesign/src/index.ts
+++ b/tdesign/src/index.ts
@@ -29,6 +29,7 @@ export {
   HeaderRight,
   HeaderCenter,
   MainContent,
+  PaddedSingleCol,
 } from "./Layout/index";
 
 export { Menu, MenuItem, MenuItemHeading } from "./Menu";

--- a/tdesign/src/themes/muiTheme.ts
+++ b/tdesign/src/themes/muiTheme.ts
@@ -24,17 +24,67 @@ export const muiTheme = ({
   // Deep merge should perform better, at a hopefully small hit to readability
   // more info https://stackoverflow.com/questions/57630926/material-ui-theme-overrides-leveraging-theme-palette-colors
 
+  const baseGrid: React.CSSProperties = {
+    display: "grid",
+    gridColumnGap: "0px",
+    gridAutoFlow: "column",
+  };
+
+  // Known values that will not change
+  const magicNumbers = {
+    logo: {
+      padding: "22.5px",
+      margin: "37px",
+      width: "100px",
+    },
+    nav: {
+      rightMargin: "37px",
+      profile: {
+        paddingRight: "8px",
+        padding: "16px",
+        width: "40px",
+        fromRightOfPageToLeftOfMenu: "65px",
+      },
+      // Note: the width of the nav links is NOT known (it varies)
+      // Including it here to make that obvious.
+      links: {
+        width: "0px",
+      },
+    },
+  };
+
+  const constants = {
+    leftMargin: `max(0px, calc((100vw - ${breakpointValues.desktop}px) / 2))`,
+    rightMargin: `max(0px, calc((100vw - ${breakpointValues.desktop}px) / 2))`,
+
+    /** Align with left side of wordmark, right side of nav */
+    leftMarginLogoAligned: `max(2rem, calc((100vw - ${breakpointValues.desktop}px) / 2 + ${magicNumbers.logo.padding} + ${magicNumbers.logo.margin}))`,
+    rightMarginNavAligned: `max(2rem, calc((100vw - ${breakpointValues.desktop}px) / 2) + ${magicNumbers.nav.profile.paddingRight})`,
+
+    /** Align with right (inner) side of wordmark, left (inner) side of ProfileMenu */
+    leftMarginInsideLogo: `max(2rem, calc((100vw - ${breakpointValues.desktop}px) / 2 + ${magicNumbers.logo.padding} + ${magicNumbers.logo.margin}) + ${magicNumbers.logo.width})`,
+
+    /** Align with left (inner) side of ProfileMenu component (assumes logged in)
+     * Note: There is no constant including the nav links because their width is unknown
+     */
+    rightMarginInsideNavProfileMenu: `max(2rem, calc((100vw - ${breakpointValues.desktop}px) / 2) + ${magicNumbers.nav.profile.fromRightOfPageToLeftOfMenu})`,
+    brandGradient: `linear-gradient(90deg, rgb(249 69 105 / 100%) 0%, rgb(255 128 153 / 50%) 100%)`,
+  };
+
   const baseTheme = createMuiTheme({
     breakpoints: {
       values: breakpointValues,
     },
-    constants: {
-      leftMargin: `max(0px, calc((100vw - ${breakpointValues.desktop}px) / 2))`,
-      rightMargin: `max(0px, calc((100vw - ${breakpointValues.desktop}px) / 2))`,
-      leftMarginLogoAligned: `max(0px, calc((100vw - ${breakpointValues.desktop}px) / 2 + 22.5px + 40px))`,
-      rightMarginNavAligned: `max(0px, calc((100vw - ${breakpointValues.desktop}px) / 2))`,
-      brandGradient: `linear-gradient(90deg, rgb(249 69 105 / 100%) 0%, rgb(255 128 153 / 50%) 100%)`,
+    constants: constants,
+    grids: {
+      threeCol: {
+        ...baseGrid,
+        gridTemplateColumns:
+          "min-content repeat(1, minmax(25vw, 1fr)) min-content",
+        gridAutoFlow: "column",
+      },
     },
+    // min-content repeat(1, minmax(25vw, 1fr)) min-content
     palette: {
       primary: {
         main: userPrimaryColor || "#F94569",
@@ -587,8 +637,23 @@ declare module "@material-ui/core/styles/createPalette" {
 // Docs on module augmentation for customizing the theme
 // https://material-ui.com/guides/typescript/#customization-of-theme
 declare module "@material-ui/core/styles" {
+  type Constants = {
+    leftMargin: string;
+    rightMargin: string;
+    leftMarginLogoAligned: string;
+    rightMarginNavAligned: string;
+    leftMarginInsideLogo: string;
+    rightMarginInsideNavProfileMenu: string;
+    brandGradient: string;
+  };
+
+  type GridDefs = {
+    threeCol: React.CSSProperties;
+  };
+
   interface Theme {
-    constants?: { [key: string]: number | string };
+    constants: Constants;
+    grids: GridDefs;
     texturize: (
       base: React.CSSProperties,
       texture: React.CSSProperties
@@ -596,7 +661,8 @@ declare module "@material-ui/core/styles" {
   }
   // allow configuration using `createTheme`
   interface ThemeOptions {
-    constants?: { [key: string]: number | string };
+    constants: Constants;
+    grids: GridDefs;
     texturize: (
       base: React.CSSProperties,
       texture: React.CSSProperties


### PR DESCRIPTION
This PR attempts to marginally (haha) improve the theme. A recent bugfix in the downstream parent repository depends on this branch. I want to merge that bugfix, but its submodule is already pointing to the current HEAD of this branch, so there is no rush to merge this one.

So I'll leave this PR open and suggest we use it to review / discuss the theme and MUI strategy more generally. The current theme replaced the previous `theme-ui` theme, and so far the focus has been "make it work" with the existing components.  And @onpaws has added some light/dark and user-derived color theme-ability to it, but none of us have focused yet on optimizing maintainability / type safety / efficiency .

I think @onpaws already has some ideas here and is coming back to this file in the near future. And it would be great to get input from @Gelio on the MUI approach here as well. @pushkatel has also been working with this code recently and I wrote some notes in the commit messages based on our discussions.

For the contents of this PR, read the commit body. It adds magic numbers based on known widths to clamp the main content to align with elements outside its hierarchy, and arguably improves type safety of the theme.

Roughly, I think the main areas for improvement are:

- (separately: Upgrade TypeScript, Node, MUI, Emotion)
- Reduce cost of typechecking, identify expensive techniques, and ideally add a linting rule to warn us about them 
- Refactor `muiTheme.ts` into multiple files
- Figure out a solid variant strategy (see @onpaws comment about `BoxOverride`)
- Review usage of `sx` (runtime and typechecking expense) vs. variants
- Maybe refactor import/exports of `tdesign` (barrel files)
- Separate what should be in the theme (vary based on dark/light/color config) from what's constant
- Identify which pages still depend on values from the old theme-ui theme, and delete as much of the theme as possible
- Reduce the need for `long.path.to.theme.value` accessors
- Isolate MUI as a dependency : Re-export it from `tdesign` and replace downstream references with that re-export. This makes it easier to move an individual component off of MUI.
- would be nice: Fully support styled components and the emotion css prop
- Make `MuiLink` more compatible with `next/link` in a cleaner way (this was original source of typechecking expense)

Really the best way to identify the pain points is while developing a new component on the frontend and seeing all the friction required. Ideally we can have a simple doc for how to consume the theme, and how do common tasks with it. IMO the most frustrating unanswered question is variants. 

I like the `BoxOverride` that @onpaws figured out:

https://github.com/splitgraph/splitgraph.com/blob/8c91bd5f3e02f90f8d59335eb302b8565f145081/tdesign/src/Box/BoxOverride.tsx

Personally my frustration working with MUI is that it feels like it's getting in my way, compared to `styled.div`, class names, and raw CSS. And every time I add something to the theme it feels like throwing more onto the pile of technical debt. This is probably because I'm using it wrong. :) 

All input welcome! 