### PR TITLE
Fix `withMUITheme` typing

### DIFF
--- a/tdesign/src/themes/withMUITheme.tsx
+++ b/tdesign/src/themes/withMUITheme.tsx
@@ -1,4 +1,7 @@
-import { getDisplayName } from "next/dist/next-server/lib/utils";
+import {
+  getDisplayName,
+  NextComponentType,
+} from "next/dist/next-server/lib/utils";
 
 // import { CacheProvider } from "@emotion/react";
 // import createCache from "@emotion/cache";
@@ -8,11 +11,15 @@ import UserTheme from "./UserTheme";
 // If multiple instances of Emotion + caching becomes a problem again, see:
 // https://github.com/emotion-js/emotion/issues/2210#issuecomment-758577800
 
-const withMUITheme = (Page) => {
-  const WithMUITheme = (props) => {
+const withMUITheme = <PageContext extends {}, IP extends {}, Props extends {}>(
+  Page: NextComponentType<PageContext, IP, Props>
+) => {
+  const WithMUITheme: NextComponentType<PageContext, IP, Props> = (props) => {
     return (
       <UserTheme>
-        <Page {...props} />
+        {/* NOTE: Props are not modified in any way - we can safely ignore
+          type-checking error here */}
+        <Page {...(props as any)} />
       </UserTheme>
     );
   };

--- a/tdesign/src/themes/withMUITheme.tsx
+++ b/tdesign/src/themes/withMUITheme.tsx
@@ -1,7 +1,5 @@
-import {
-  getDisplayName,
-  NextComponentType,
-} from "next/dist/next-server/lib/utils";
+import type { NextPage } from "next";
+import { getDisplayName } from "next/dist/next-server/lib/utils";
 
 // import { CacheProvider } from "@emotion/react";
 // import createCache from "@emotion/cache";
@@ -11,10 +9,10 @@ import UserTheme from "./UserTheme";
 // If multiple instances of Emotion + caching becomes a problem again, see:
 // https://github.com/emotion-js/emotion/issues/2210#issuecomment-758577800
 
-const withMUITheme = <PageContext extends {}, IP extends {}, Props extends {}>(
-  Page: NextComponentType<PageContext, IP, Props>
+const withMUITheme = <Props extends {}, IP extends {}>(
+  Page: NextPage<Props, IP>
 ) => {
-  const WithMUITheme: NextComponentType<PageContext, IP, Props> = (props) => {
+  const WithMUITheme: NextPage<Props, IP> = (props) => {
     return (
       <UserTheme>
         {/* NOTE: Props are not modified in any way - we can safely ignore


### PR DESCRIPTION
This PR uses `master` as the base branch but includes commits from #138 because that was the commit that is used as the submodule hash in the parent repo. I have described the problem in https://github.com/splitgraph/splitgraph.com/pull/138#issuecomment-967179632.

Please review only the last commit :smile:

For the description of the problem, see the commit message.