### PR TITLE
Improve references and include patterns in tsconfigs

### DIFF
--- a/templaters/tsconfig.json
+++ b/templaters/tsconfig.json
@@ -4,19 +4,10 @@
     "**/*.js",
     "**/*.ts",
     "**/*.tsx",
-    "../docs/compile/*.js",
-    "../docs/components/*.tsx",
-    "../docs/hocs/*.tsx",
-    "../docs/components/*.ts",
-    "../docs/hocs/*.ts",
-    "../docs/components/*.js",
-    "../docs/hocs/*.js",
-    "../docs/components/**/*.tsx",
-    "../docs/hocs/**/*.tsx",
-    "../docs/components/**/*.ts",
-    "../docs/hocs/**/*.ts",
-    "../docs/components/**/*.js",
-    "../docs/hocs/**/*.js"
+    // NOTE: wasteful and surprising to include those files in 2 TS projects, but cannot be avoided due
+    // to inter-dependencies between TS projects
+    "../docs/components/**/*",
+    "../docs/compile/**/*"
   ],
   "references": [{ "path": "../tdesign" }, { "path": "../design" }]
 }

--- a/tsconfig.ci.json
+++ b/tsconfig.ci.json
@@ -32,13 +32,13 @@
       "@splitgraph/*": ["*"]
     }
   },
-  "include": [
-    "content",
-    "content-scripts",
-    "design",
-    "docs",
-    "tdesign",
-    "templaters"
+  "include": ["content", "content-scripts", "design"],
+  "references": [
+    { "path": "tdesign" },
+    { "path": "docs" },
+    { "path": "lib" },
+    { "path": "react-dropzone-uploader-wrapper" },
+    { "path": "templaters" }
   ],
   "exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,13 @@
     "rootDir": ".",
     "outDir": "dist"
   },
-  "exclude": ["node_modules"]
-  // "references": [{ "path": "tdesign" }, { "path": "docs" }]
+  "exclude": ["node_modules"],
+  "include": ["content", "content-scripts", "design"],
+  "references": [
+    { "path": "tdesign" },
+    { "path": "docs" },
+    { "path": "lib" },
+    { "path": "react-dropzone-uploader-wrapper" },
+    { "path": "templaters" }
+  ]
 }


### PR DESCRIPTION
Attempt to reuse compilation results by including as few files in TS projects as possible. Leverage TS references when possible instead of including files again.

See a corresponding MR in the parent repository for more details.

- [CU-1w8mkyq](https://app.clickup.com/t/1w8mkyq)