### PR TITLE
Remove `message` text and `Upload` header from `Upload` in `tdesign`

### DIFF
--- a/tdesign/src/Upload/Upload.tsx
+++ b/tdesign/src/Upload/Upload.tsx
@@ -38,7 +38,6 @@ interface IUploadProps extends BoxProps {
     successFiles: IFileWithMeta[],
     allFiles: IFileWithMeta[]
   ) => void;
-  message?: string;
   small?: boolean;
   handleChangeStatus?: IDropzoneProps["onChangeStatus"];
   onSubmitAfterFilesUploaded?: () => void;
@@ -50,7 +49,6 @@ const Upload = ({
   accept,
   getUploadParams,
   handleSubmit,
-  message,
   small,
   handleChangeStatus,
   onSubmitAfterFilesUploaded,
@@ -63,10 +61,6 @@ const Upload = ({
   }: ILayoutProps) => {
     return (
       <div {...dropzoneProps}>
-        <Typography variant="title1">Upload</Typography>
-        <br />
-        {!!message && <Typography variant="body">{message}</Typography>}
-        <br />
         {input}
         <Box sx={{ marginBottom: "1rem" }}>{submitButton}</Box>
         {!!files?.length && (


### PR DESCRIPTION
- This messaging is unrelated to the upload component and should be
the responsibility of the consumer.
- In the parent repo, the corresponding MR moves this to its own
component `UploadHeading` that can be optionally rendered alongside
the `Upload` component (e.g. in the case of a full page), or not
rendered at all (e.g. in the case of embedding)