### PR TITLE
Add MarketingNotice component, and deprecate previous one with same name

### DIFF
--- a/docs/components/MarketingNotice/MarketingNotice.tsx
+++ b/docs/components/MarketingNotice/MarketingNotice.tsx
@@ -6,6 +6,11 @@ export interface IMarketingNoticeProps {
   children?: React.ReactNode;
 }
 
+/** @deprecated This is only used on some old marketing site pages
+ * (e.g. /connect).
+ *
+ * superceded by another file called MarketingNotice in tdesign
+ */
 const MarketingNotice = ({
   children,
   defaultShowBar = true,

--- a/tdesign/src/Layout/BaseLayout/BaseLayout.tsx
+++ b/tdesign/src/Layout/BaseLayout/BaseLayout.tsx
@@ -20,6 +20,7 @@ export interface BaseLayoutProps extends Omit<ILogoProps, "linkTo"> {
   extraStyle?: SxProps<Theme>;
   showHeader?: boolean;
   logoLinkTo?: ILogoProps["linkTo"];
+  marketingNotice?: React.ReactNode;
 }
 
 const BaseLayout = ({
@@ -34,6 +35,7 @@ const BaseLayout = ({
   logoText,
   brandName,
   logoLinkTo = "/",
+  marketingNotice = null,
 }: BaseLayoutProps) => {
   const containerStyle: SxProps<Theme> = {
     // TODO: Deprecated variant syntax only works with legacyTheme
@@ -103,6 +105,7 @@ const BaseLayout = ({
 
   return (
     <Box sx={containerStyle}>
+      {marketingNotice}
       {showHeader && (
         <Header>
           <HeaderLeft>

--- a/tdesign/src/Layout/BaseLayout/BaseLayout.tsx
+++ b/tdesign/src/Layout/BaseLayout/BaseLayout.tsx
@@ -35,7 +35,7 @@ const BaseLayout = ({
   logoText,
   brandName,
   logoLinkTo = "/",
-  marketingNotice = null,
+  marketingNotice,
 }: BaseLayoutProps) => {
   const containerStyle: SxProps<Theme> = {
     // TODO: Deprecated variant syntax only works with legacyTheme

--- a/tdesign/src/Layout/MarketingNotice/MarketingNotice.tsx
+++ b/tdesign/src/Layout/MarketingNotice/MarketingNotice.tsx
@@ -1,0 +1,65 @@
+import * as React from "react";
+import { styled } from "@mui/material/styles";
+import type { muiTheme } from "@splitgraph/tdesign/src/themes/muiTheme";
+import { Button } from "@mui/material";
+
+interface CallToActionOpts {
+  href: string;
+}
+
+interface MarketingNoticeProps {
+  cta?: React.PropsWithChildren<CallToActionOpts>;
+}
+
+const MarketingNoticeContainer = styled("div")(
+  ({ theme }: { theme: ReturnType<typeof muiTheme> }) => ({
+    paddingTop: "14px",
+    paddingBottom: "14px",
+    paddingLeft: `calc(5px + ${theme.constants.leftMarginLogoAligned})`,
+    paddingRight: theme.constants.rightMarginNavAligned,
+    background: theme.constants.pinkBackgroundGradient,
+    display: "flex",
+    alignItems: "center",
+  })
+);
+
+const CenteredChildrenContainer = styled("div")({
+  color: "heavy.main",
+  flexGrow: 1,
+  display: "flex",
+  justifyContent: "center",
+});
+
+const RightAlignedCTAContainer = styled("div")({
+  alignSelf: "flex-end",
+});
+
+const CTAButton = styled(Button)(
+  ({ theme }: { theme: ReturnType<typeof muiTheme> }) => ({
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: theme.palette.flambeeRed.light,
+    boxShadow: "none",
+    borderRadius: "10px",
+    margin: 0,
+    paddingTop: "5px",
+    paddingBottom: "5px",
+    paddingLeft: ".5rem",
+    paddingRight: ".5rem",
+    fontSize: "14px",
+  })
+);
+
+export const MarketingNotice = ({
+  children,
+  cta,
+}: React.PropsWithChildren<MarketingNoticeProps>) => {
+  return (
+    <MarketingNoticeContainer>
+      <CenteredChildrenContainer>{children}</CenteredChildrenContainer>
+      <RightAlignedCTAContainer>
+        <CTAButton {...cta} />
+      </RightAlignedCTAContainer>
+    </MarketingNoticeContainer>
+  );
+};

--- a/tdesign/src/Layout/MarketingNotice/MarketingNotice.tsx
+++ b/tdesign/src/Layout/MarketingNotice/MarketingNotice.tsx
@@ -3,12 +3,8 @@ import { styled } from "@mui/material/styles";
 import type { muiTheme } from "@splitgraph/tdesign/src/themes/muiTheme";
 import { Button } from "@mui/material";
 
-interface CallToActionOpts {
-  href: string;
-}
-
 interface MarketingNoticeProps {
-  cta?: React.PropsWithChildren<CallToActionOpts>;
+  cta?: React.ReactNode;
 }
 
 const MarketingNoticeContainer = styled("div")(
@@ -34,7 +30,7 @@ const RightAlignedCTAContainer = styled("div")({
   alignSelf: "flex-end",
 });
 
-const CTAButton = styled(Button)(
+export const CTAButton = styled(Button)(
   ({ theme }: { theme: ReturnType<typeof muiTheme> }) => ({
     borderWidth: "1px",
     borderStyle: "solid",
@@ -57,9 +53,7 @@ export const MarketingNotice = ({
   return (
     <MarketingNoticeContainer>
       <CenteredChildrenContainer>{children}</CenteredChildrenContainer>
-      <RightAlignedCTAContainer>
-        <CTAButton {...cta} />
-      </RightAlignedCTAContainer>
+      {!!cta && <RightAlignedCTAContainer>{cta}</RightAlignedCTAContainer>}
     </MarketingNoticeContainer>
   );
 };

--- a/tdesign/src/Layout/MarketingNotice/index.ts
+++ b/tdesign/src/Layout/MarketingNotice/index.ts
@@ -1,0 +1,1 @@
+export * from "./MarketingNotice";

--- a/tdesign/src/Layout/index.tsx
+++ b/tdesign/src/Layout/index.tsx
@@ -27,3 +27,5 @@ export { Logo } from "./Logo";
 export type { ILogoProps } from "./Logo";
 
 export { PaddedSingleCol } from "./PaddedSingleCol";
+
+export * from "./MarketingNotice";

--- a/tdesign/src/index.ts
+++ b/tdesign/src/index.ts
@@ -31,6 +31,7 @@ export {
   MainContent,
   PaddedSingleCol,
   MarketingNotice,
+  CTAButton,
 } from "./Layout/index";
 
 export { Menu, MenuItem, MenuItemHeading } from "./Menu";

--- a/tdesign/src/index.ts
+++ b/tdesign/src/index.ts
@@ -30,6 +30,7 @@ export {
   HeaderCenter,
   MainContent,
   PaddedSingleCol,
+  MarketingNotice,
 } from "./Layout/index";
 
 export { Menu, MenuItem, MenuItemHeading } from "./Menu";


### PR DESCRIPTION
This adds a component for rendering a `MarketingNotice`, likely at the top of the page, with custom text (its `children`) and custom CTA button props.