### PR TITLE
Chore: Disable MUI ripple for <ButtonGroup>

### DIFF
--- a/tdesign/src/themes/muiTheme.ts
+++ b/tdesign/src/themes/muiTheme.ts
@@ -279,6 +279,11 @@ export const muiTheme = ({
           disableRipple: true,
         },
       },
+      MuiButtonGroup: {
+        defaultProps: {
+          disableRipple: true,
+        },
+      },
       MuiOutlinedInput: {
         defaultProps: {
           notched: false,


### PR DESCRIPTION
### TL,DR
This change seeks to disable the ripple from `MuiButtonGroup`. It's similar to what we already did for `MuiButtonBase`.

### Backstory
For the Data Source widget, there's a chance may use a so-called `<ButtonGroup>` component, which is a MUI term for this kind of button + dropdown mashup:
<img width="381" alt="image" src="https://user-images.githubusercontent.com/182515/152439043-4914a552-d614-4a89-9383-757bfb769648.png">

TIL that when I used `<ButtonGroup>` in catalog, the ripples came back which was a mild surprise. Turns out it gets its own separate field in the theme file.