### PR TITLE
Extract SplitButton into tdesign

### DIFF
--- a/tdesign/src/Button/SplitButton.tsx
+++ b/tdesign/src/Button/SplitButton.tsx
@@ -1,0 +1,102 @@
+import * as React from "react";
+import {
+  Button,
+  ButtonGroup,
+  Grow,
+  Paper,
+  Popper,
+  MenuItem,
+  MenuList,
+} from "@mui/material";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import ClickAwayListener from "@mui/material/ClickAwayListener";
+
+const options = ["Sync...", "Full reload..."];
+
+export const SplitButton = () => {
+  const [open, setOpen] = React.useState(false);
+  const anchorRef = React.useRef<HTMLDivElement>(null);
+  const [selectedIndex, setSelectedIndex] = React.useState(0);
+
+  const handleClick = () => {
+    console.info(`You clicked ${options[selectedIndex]}`);
+  };
+
+  const handleMenuItemClick = (
+    _: React.MouseEvent<HTMLLIElement, MouseEvent>,
+    index: number
+  ) => {
+    setSelectedIndex(index);
+    setOpen(false);
+  };
+
+  const handleToggle = () => {
+    setOpen((prevOpen) => !prevOpen);
+  };
+
+  const handleClose = (event: Event) => {
+    if (
+      anchorRef.current &&
+      anchorRef.current.contains(event.target as HTMLElement)
+    ) {
+      return;
+    }
+
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <ButtonGroup
+        variant="contained"
+        ref={anchorRef}
+        aria-label="split button"
+      >
+        <Button onClick={handleClick}>{options[selectedIndex]}</Button>
+        <Button
+          size="small"
+          aria-controls={open ? "split-button-menu" : undefined}
+          aria-expanded={open ? "true" : undefined}
+          aria-label="select merge strategy"
+          aria-haspopup="menu"
+          onClick={handleToggle}
+        >
+          <ArrowDropDownIcon />
+        </Button>
+      </ButtonGroup>
+      <Popper
+        open={open}
+        anchorEl={anchorRef.current}
+        role={undefined}
+        transition
+        disablePortal
+      >
+        {({ TransitionProps, placement }) => (
+          <Grow
+            {...TransitionProps}
+            style={{
+              transformOrigin:
+                placement === "bottom" ? "center top" : "center bottom",
+            }}
+          >
+            <Paper>
+              <ClickAwayListener onClickAway={handleClose}>
+                <MenuList id="split-button-menu">
+                  {options.map((option, index) => (
+                    <MenuItem
+                      key={option}
+                      selected={index === selectedIndex}
+                      onClick={(event) => handleMenuItemClick(event, index)}
+                    >
+                      {option}
+                    </MenuItem>
+                  ))}
+                </MenuList>
+              </ClickAwayListener>
+            </Paper>
+          </Grow>
+        )}
+      </Popper>
+    </>
+  );
+};

--- a/tdesign/src/Button/index.ts
+++ b/tdesign/src/Button/index.ts
@@ -5,6 +5,7 @@ export { default as PrimaryButton } from "./PrimaryButton";
 export { default as Button } from "./Button";
 export { default as InvisibleButton } from "./InvisibleButton";
 export { default as LinkButton } from "./LinkButton";
+export { SplitButton } from "./SplitButton";
 
 export type { IButtonProps } from "./Button";
 export type { IInFieldButtonProps } from "./InFieldButton";

--- a/tdesign/src/index.ts
+++ b/tdesign/src/index.ts
@@ -16,6 +16,7 @@ export {
   Button,
   InvisibleButton,
   LinkButton,
+  SplitButton,
 } from "./Button/index";
 export type {
   IButtonProps,


### PR DESCRIPTION
- Unlike the other data source related changes, this has a higher potential for re-use and seems appropriate for tdesign
- SplitButton, while a WIP right now, is being considered for the repo page's data source widget

- CU-29a25tx