### PR TITLE
Fix bug where 'ErrorAlert2' always rendered dismissLinkHref as '#'

### DIFF
--- a/tdesign/src/Alert/ErrorAlert2.tsx
+++ b/tdesign/src/Alert/ErrorAlert2.tsx
@@ -23,8 +23,8 @@ interface ErrorResetLinkProps {
   href?: string;
 }
 
-const ErrorResetLink = ({ text }: ErrorResetLinkProps) => (
-  <MuiLink href={"#"}>{text}</MuiLink>
+const ErrorResetLink = ({ text, href }: ErrorResetLinkProps) => (
+  <MuiLink href={href ?? "#"}>{text}</MuiLink>
 );
 
 export interface IErrorAlertProps {


### PR DESCRIPTION
This PR contains a small bugfix that prevented the user from dismissing flash alerts rendered with `ErrorAlert2` because `dismissLinkHref` was always set to `#`.

I'm merging it so that I can point the cloud repo to `master`.