### PR TITLE
Remove unnecessary theme type annotations for styled API

### DIFF
--- a/docs/components/DemoComponents/styled-util-fn.tsx
+++ b/docs/components/DemoComponents/styled-util-fn.tsx
@@ -1,5 +1,5 @@
 import { Typography, Slider } from "@mui/material";
-import { experimentalStyled as styled } from "@mui/material/styles";
+import { styled } from "@mui/material/styles";
 
 const CustomizedSlider = styled(Slider)`
   color: #20b2aa;
@@ -17,9 +17,7 @@ export default function StyledComponents() {
       <CustomizedSlider defaultValue={30} />
       <p>
         MUI wraps{" "}
-        <a href="https://next.material-ui.com/guides/interoperability/#styled-components">
-          Emotion's styled()
-        </a>
+        <a href="https://mui.com/system/styled/">Emotion's styled()</a>
       </p>
     </div>
   );

--- a/tdesign/src/Layout/MarketingNotice/MarketingNotice.tsx
+++ b/tdesign/src/Layout/MarketingNotice/MarketingNotice.tsx
@@ -1,23 +1,20 @@
 import * as React from "react";
 import { styled } from "@mui/material/styles";
-import type { muiTheme } from "@splitgraph/tdesign/src/themes/muiTheme";
 import { Button } from "@mui/material";
 
 interface MarketingNoticeProps {
   cta?: React.ReactNode;
 }
 
-const MarketingNoticeContainer = styled("div")(
-  ({ theme }: { theme: ReturnType<typeof muiTheme> }) => ({
-    paddingTop: "14px",
-    paddingBottom: "14px",
-    paddingLeft: `calc(5px + ${theme.constants.leftMarginLogoAligned})`,
-    paddingRight: theme.constants.rightMarginNavAligned,
-    background: theme.constants.pinkBackgroundGradient,
-    display: "flex",
-    alignItems: "center",
-  })
-);
+const MarketingNoticeContainer = styled("div")(({ theme }) => ({
+  paddingTop: "14px",
+  paddingBottom: "14px",
+  paddingLeft: `calc(5px + ${theme.constants.leftMarginLogoAligned})`,
+  paddingRight: theme.constants.rightMarginNavAligned,
+  background: theme.constants.pinkBackgroundGradient,
+  display: "flex",
+  alignItems: "center",
+}));
 
 const CenteredChildrenContainer = styled("div")({
   color: "heavy.main",
@@ -30,21 +27,19 @@ const RightAlignedCTAContainer = styled("div")({
   alignSelf: "flex-end",
 });
 
-export const CTAButton = styled(Button)(
-  ({ theme }: { theme: ReturnType<typeof muiTheme> }) => ({
-    borderWidth: "1px",
-    borderStyle: "solid",
-    borderColor: theme.palette.flambeeRed.light,
-    boxShadow: "none",
-    borderRadius: "10px",
-    margin: 0,
-    paddingTop: "5px",
-    paddingBottom: "5px",
-    paddingLeft: ".5rem",
-    paddingRight: ".5rem",
-    fontSize: "14px",
-  })
-);
+export const CTAButton = styled(Button)(({ theme }) => ({
+  borderWidth: "1px",
+  borderStyle: "solid",
+  borderColor: theme.palette.flambeeRed.light,
+  boxShadow: "none",
+  borderRadius: "10px",
+  margin: 0,
+  paddingTop: "5px",
+  paddingBottom: "5px",
+  paddingLeft: ".5rem",
+  paddingRight: ".5rem",
+  fontSize: "14px",
+}));
 
 export const MarketingNotice = ({
   children,


### PR DESCRIPTION
When importing `styled` from `@mui/material` (or
`@mui/material/styles`), the `theme` type is correctly augmented by the
code in muiTheme. It has all theme properties defined in TypeScript.
There is no need to import the `muiTheme` type and assign it manually.

Theme type annotation is still needed when using the `styled` API from
`@mui/system`. This means we should always use `styled` from
`@mui/material` since it has the correct `theme` type out of the box.

- CU-1y83wkm