### PR TITLE
Stretch colored icons

### DIFF
--- a/.github/actions/notifier-start/action.yml
+++ b/.github/actions/notifier-start/action.yml
@@ -14,7 +14,12 @@ runs:
       run: |
         echo "BRANCH_NAME="${GITHUB_REF#refs/heads/}"" >> $GITHUB_ENV
         echo "SHORT_COMMIT="${GITHUB_SHA:0:8}"" >> $GITHUB_ENV
-        echo "COMMIT_MSG_TRUNCATED="${COMMIT_MSG:0:50}"" >> $GITHUB_ENV
+        unescaped_commit_msg_truncated="${COMMIT_MSG:0:50}"
+        # NOTE: escape backticks in the commit message
+        # Prevents errors when a backtick is used in the first 50 characters of
+        # the commit message
+        # See https://github.com/splitgraph/splitgraph.com/runs/6191036770?check_suite_focus=true
+        echo "COMMIT_MSG_TRUNCATED="${unescaped_commit_msg_truncated//\`/\\\`}"" >> $GITHUB_ENV
         echo "START_TIME="$(printf '%(%s)T\n' -1)"" >> $GITHUB_ENV
     - name: Setup Notification Preamble
       id: setup_notification_preamble

--- a/tdesign/src/Icon/BaseIcon.tsx
+++ b/tdesign/src/Icon/BaseIcon.tsx
@@ -35,11 +35,13 @@ export const makeIconStyle = ({
 }: IMakeIconStyleArgs) => {
   const svgDataURI = `url("${svgURI}")`;
 
-  const maskStyle = {
+  const maskStyle: SxProps<Theme> = {
     WebkitMaskImage: svgDataURI,
     maskImage: svgDataURI,
     WebkitMaskRepeat: "no-repeat",
     maskRepeat: "no-repeat",
+    WebKitMaskSize: "contain",
+    maskSize: "contain",
   };
 
   const style: SxProps<Theme> = {


### PR DESCRIPTION
Fix icon sizes when the `color` prop is specified to stretch according to the specified `size`.

The `backgroundSize` style has an effect only when the `color` prop is not specified, because then, the whole SVG is used as a background and then resized according to `backgroundSize`.

When the `color` prop is specified, the icon SVG is used as a mask, which is not resized by default. This means the icon had the same dimensions as defined in the SVG data URI.

The mask-size CSS property fixes this problem by having the mask cover the whole element (according to its `size`). This way the icon has the same size regardless of whether it has a `color` specified or not.

## Verification

I clicked around the app a bit and looked at the icon sizes to see if they stand out now. I didn't find anything worrying.

## Media

| `color` presence | Before | After | Summary |
|--|--|--|--|
| without `color` | ![image](https://user-images.githubusercontent.com/889383/165490036-99629b0a-8434-4489-8ec5-59cfb1f00da8.png) | ![image](https://user-images.githubusercontent.com/889383/165489905-b795ff44-5963-4dca-b323-b48a2852f9ec.png) | It's the same |
| with `color` | ![image](https://user-images.githubusercontent.com/889383/165490216-1b4a6b5b-c901-4aeb-8288-377dd34ab122.png) | ![image](https://user-images.githubusercontent.com/889383/165489616-7e00c5b4-d5f3-48a6-83f0-b708b00a9fbb.png) | Before, the icon wrapper still took up 24px, but the mask (the actual SVG) was only 16px, because that is what the data URI says.<br>The icon size remains the same now |

## Fix for the Notifier GitHub action

In this PR I encountered a bug in our Notifier GitHub action that I decided to fix. It is related to an unbalanced backtick in the truncated (first 50 characters) commit message.

Failing job: https://github.com/splitgraph/splitgraph.com/runs/6191036770?check_suite_focus=true
Passing job for the same commit (and thus, the same error message): https://github.com/splitgraph/splitgraph.com/runs/6191574351?check_suite_focus=true

The backtick is correctly escaped:

![image](https://user-images.githubusercontent.com/889383/165496435-9b118d33-e41b-4db0-aa30-d938337cb6de.png)


## References

- https://developer.mozilla.org/en-US/docs/Web/CSS/mask-size
- https://app.clickup.com/t/20xxby3