### PR TITLE
Minor/cosmetic: fix for InvisibleButton border on Safari

### DIFF
--- a/tdesign/src/Button/InvisibleButton.tsx
+++ b/tdesign/src/Button/InvisibleButton.tsx
@@ -26,10 +26,11 @@ const InvisibleButton = ({
       "&.Mui-disabled": {
         backgroundColor: ({ palette }) => palette.grays.gray26.main,
       },
-      outline: ({ palette }) => `1px solid ${palette.grays.gray25.main}`,
+      boxShadow: ({ palette }) =>
+        `0px 0px 0px 2px ${palette.grays.gray25.main}`,
       "&:hover": {
         boxShadow: ({ palette }) =>
-          `0px 0px 0px 2px ${palette.grays.gray25.main}`,
+          `0px 0px 0px 2px ${palette.grays.gray23.main}`,
         background: "transparent",
       },
       "&:focus": {

--- a/tdesign/src/Input/PasswordInput.tsx
+++ b/tdesign/src/Input/PasswordInput.tsx
@@ -10,12 +10,13 @@ import { IconPasswordHide, IconPasswordSee } from "../Icon";
 
 interface IPasswordInputProps extends OutlinedInputProps {
   extraEndAdornment?: React.ReactNode;
+  tabbable?: boolean;
 }
 
 export const PasswordInput = forwardRef<HTMLInputElement, IPasswordInputProps>(
   (props, ref) => {
     const [showPassword, setShowPassword] = useState(false);
-    const { extraEndAdornment, ...rest } = props;
+    const { extraEndAdornment, tabbable, ...rest } = props;
     const handleClickShowPassword = () => {
       setShowPassword(!showPassword);
     };
@@ -43,6 +44,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, IPasswordInputProps>(
                     `0px 0px 0px 1px ${palette.grays.gray20.main}`,
                 },
               }}
+              tabIndex={tabbable ? 0 : -1}
             >
               {showPassword ? <IconPasswordSee /> : <IconPasswordHide />}
             </IconButton>
@@ -72,6 +74,9 @@ export const PasswordInput = forwardRef<HTMLInputElement, IPasswordInputProps>(
             "& fieldset": {
               borderColor: "on.error.main",
             },
+          },
+          "::-ms-reveal": {
+            display: "none",
           },
         }}
         {...rest}


### PR DESCRIPTION
- Apparently this is an area where Chrome+Safari diverge
- Checked on FF+Safari+Chrome, it looks consistent now